### PR TITLE
external/FT-STIM/laik_ext.proto: Explicitly specify the syntax versio…

### DIFF
--- a/external/FT-STIM/laik_ext.proto
+++ b/external/FT-STIM/laik_ext.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message laik_ext_msg{
 //	required int32 num_failing_nodes = 1;
 	repeated string failing_nodes = 2;


### PR DESCRIPTION
…n to avoid a compiler warning.

Without:
```
$ protoc-c --c_out=. laik_ext.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: laik_ext.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
$
```

With:
```
$ protoc-c --c_out=. laik_ext.proto
$
```