### PR TITLE
Explicitly cast all unused parameters to (void) to avoid compiler war…

### DIFF
--- a/examples/propagation1d.c
+++ b/examples/propagation1d.c
@@ -16,6 +16,8 @@
 void runLuleshPartitioner1d(Laik_Partitioner* pr,
                             Laik_BorderArray* ba, Laik_BorderArray* otherBA)
 {
+    (void) pr; /* FIXME: Why have this parameter if it's never used */
+
     assert(ba->space->dims == otherBA->space->dims);
     Laik_Space* space = ba->space;
     //Laik_Group* g = ba->group;

--- a/examples/propagation2d.c
+++ b/examples/propagation2d.c
@@ -24,6 +24,9 @@
 void runLuleshElementPartitioner(Laik_Partitioner* pr,
                                    Laik_BorderArray* ba, Laik_BorderArray* otherBA)
 {
+    (void) pr;      /* FIXME: Why have this parameter if it's never used */
+    (void) otherBA; /* FIXME: Why have this parameter if it's never used */
+
     Laik_Space* space = laik_borderarray_getspace(ba);
     const Laik_Slice* slice = laik_space_getslice(space);
     Laik_Group* group = laik_borderarray_getgroup(ba);
@@ -62,6 +65,8 @@ Laik_Partitioner* laik_new_lulesh_element_partitioner()
 void runLuleshNodePartitioner(Laik_Partitioner* pr,
                                 Laik_BorderArray* ba, Laik_BorderArray* otherBA)
 {
+    (void) otherBA; /* FIXME: Why have this parameter if it's never used */
+
     Laik_Space* space = laik_borderarray_getspace(ba);
     Laik_Space* otherSpace = laik_borderarray_getspace(otherBA);
     const Laik_Slice* slice = laik_space_getslice(space);

--- a/examples/vsum.c
+++ b/examples/vsum.c
@@ -39,7 +39,13 @@
 
 
 // for element-wise weighted partitioning: same as index
-double getEW(Laik_Index* i, const void* d) { return (double) i->i[0]; }
+double getEW(Laik_Index* i, const void* d)
+{
+    (void) d; /* FIXME: Why have this parameter if it's never used */
+
+    return (double) i->i[0];
+}
+
 // for task-wise weighted partitioning: skip task given as user data
 double getTW(int r, const void* d) { return ((long int)d == r) ? 0.0 : 1.0; }
 

--- a/examples/vsum2.c
+++ b/examples/vsum2.c
@@ -34,7 +34,13 @@
 #include <assert.h>
 
 // for element-wise weighted partitioning: same as index
-double getEW(Laik_Index* i, const void* d) { return (double) i->i[0]; }
+double getEW(Laik_Index* i, const void* d)
+{
+    (void) d; /* FIXME: Why have this parameter if it's never used */
+
+    return (double) i->i[0];
+}
+
 // for task-wise weighted partitioning: skip task given as user data
 double getTW(int r, const void* d) { return ((long int)d == r) ? 0.0 : 1.0; }
 

--- a/external/profiling/profilagent.c
+++ b/external/profiling/profilagent.c
@@ -194,6 +194,9 @@ Laik_Agent* agent_init(
     int argc, 
     char** argv
 ){
+    (void) argc; /* FIXME: Why have this parameter if it's never used */
+    (void) argv; /* FIXME: Why have this parameter if it's never used */
+
     Laik_Profiling_Agent* me = (Laik_Profiling_Agent*)
             calloc(1, sizeof(Laik_Profiling_Agent));
     assert(me);

--- a/src/data.c
+++ b/src/data.c
@@ -1030,6 +1030,8 @@ void initMaps(Laik_Transition* t,
               Laik_MappingList* toList, Laik_MappingList* fromList,
               Laik_SwitchStat* ss)
 {
+    (void) fromList; /* FIXME: Why have this parameter if it's never used */
+
     assert(t->initCount > 0);
     for(int i = 0; i < t->initCount; i++) {
         struct initTOp* op = &(t->init[i]);

--- a/src/partitioner.c
+++ b/src/partitioner.c
@@ -52,6 +52,9 @@ Laik_Partitioner* laik_new_partitioner(const char* name,
 void runAllPartitioner(Laik_Partitioner* pr,
                        Laik_BorderArray* ba, Laik_BorderArray* oldBA)
 {
+    (void) pr;    /* FIXME: Why have this parameter if it's never used */
+    (void) oldBA; /* FIXME: Why have this parameter if it's never used */
+
     Laik_Space* space = ba->space;
     Laik_Group* g = ba->group;
 
@@ -70,6 +73,9 @@ Laik_Partitioner* laik_new_all_partitioner()
 void runMasterPartitioner(Laik_Partitioner* pr,
                           Laik_BorderArray* ba, Laik_BorderArray* oldBA)
 {
+    (void) pr;    /* FIXME: Why have this parameter if it's never used */
+    (void) oldBA; /* FIXME: Why have this parameter if it's never used */
+
     // only full slice for master
     laik_append_slice(ba, 0, &(ba->space->s), 0, 0);
 }
@@ -305,6 +311,9 @@ static void doBisection(Laik_BorderArray* ba,
 void runBisectionPartitioner(Laik_Partitioner* pr,
                              Laik_BorderArray* ba, Laik_BorderArray* otherBA)
 {
+    (void) pr;      /* FIXME: Why have this parameter if it's never used */
+    (void) otherBA; /* FIXME: Why have this parameter if it's never used */
+
     doBisection(ba, &(ba->space->s), 0, ba->group->size);
 }
 
@@ -340,6 +349,8 @@ struct _Laik_BlockPartitionerData {
 void runBlockPartitioner(Laik_Partitioner* pr,
                          Laik_BorderArray* ba, Laik_BorderArray* oldBA)
 {
+    (void) oldBA; /* FIXME: Why have this parameter if it's never used */
+
     Laik_BlockPartitionerData* data;
     data = (Laik_BlockPartitionerData*) pr->data;
 

--- a/src/space.c
+++ b/src/space.c
@@ -1493,6 +1493,10 @@ void laik_calc_partitioning(Laik_Partitioning* p)
 bool laik_index_global2local(Laik_BorderArray* ba,
                              Laik_Index* global, Laik_Index* local)
 {
+    (void) ba;     /* FIXME: Why have this parameter if it's never used */
+    (void) global; /* FIXME: Why have this parameter if it's never used */
+    (void) local;  /* FIXME: Why have this parameter if it's never used */
+
     // TODO
 
     return true;
@@ -1503,6 +1507,9 @@ bool laik_index_global2local(Laik_BorderArray* ba,
 // be enforced at the same point in time
 void laik_append_partitioning(Laik_PartGroup* g, Laik_Partitioning* p)
 {
+    (void) g; /* FIXME: Why have this parameter if it's never used */
+    (void) p; /* FIXME: Why have this parameter if it's never used */
+
     assert(0); // TODO
 }
 
@@ -2347,6 +2354,9 @@ laik_calc_transition(Laik_Group* group, Laik_Space* space,
 Laik_Transition* laik_calc_transitionG(Laik_PartGroup* from,
                                        Laik_PartGroup* to)
 {
+    (void) from; /* FIXME: Why have this parameter if it's never used */
+    (void) to;   /* FIXME: Why have this parameter if it's never used */
+
     // Laik_Transition* t;
 
     assert(0); // TODO
@@ -2355,6 +2365,9 @@ Laik_Transition* laik_calc_transitionG(Laik_PartGroup* from,
 // enforce consistency for the partitioning group, depending on previous
 void laik_enforce_consistency(Laik_Instance* i, Laik_PartGroup* g)
 {
+    (void) i; /* FIXME: Why have this parameter if it's never used */
+    (void) g; /* FIXME: Why have this parameter if it's never used */
+
     assert(0); // TODO
 }
 
@@ -2363,6 +2376,9 @@ void laik_enforce_consistency(Laik_Instance* i, Laik_PartGroup* g)
 // one partition of calling task in outer space is mapped to inner space
 void laik_couple_nested(Laik_Space* outer, Laik_Space* inner)
 {
+    (void) outer; /* FIXME: Why have this parameter if it's never used */
+    (void) inner; /* FIXME: Why have this parameter if it's never used */
+
     assert(0); // TODO
 }
 


### PR DESCRIPTION
…nings.