### PR TITLE
include/interface/agent.h: Stop using the same identifier for type an…

### DIFF
--- a/include/interface/agent.h
+++ b/include/interface/agent.h
@@ -129,10 +129,10 @@ typedef void (*laik_agent_shut_node) (int uuid);
 
 typedef void (*get_default_counters) (long long*, long long*, long long*, long long*);
 typedef void (*add_counter) (int);
-typedef int (*peek) (void);
+typedef int (*peek_t) (void);
 typedef void (*op) (void);
 typedef void (*get_all_counters) (int* time, counter_kvp_t*);
-typedef double (*gettime) (void);
+typedef double (*gettime_t) (void);
 
 /* -------------- DATASTRUCTURES -------------- */
 
@@ -181,8 +181,8 @@ struct tag_laik_ext_profile_agent{
     get_default_counters read_def;
     add_counter add_c;
     get_all_counters read_all;
-    gettime gettime;
-    peek peek;
+    gettime_t gettime;
+    peek_t peek;
     op start;
     op end;
 


### PR DESCRIPTION
…d variable names.

In C, type names and variable names aren't strictly separated (they can for
example both be passed to the sizeof() function). This causes the error below
when -Wpedantic is enabled. Fix this by appending the _t suffix to typenames
like everybody else does.

```
In file included from ../src/../include/laik/ext.h:22:0,
                 from ../src/../include/laik.h:28,
                 from ../src/../include/laik-backend-mpi.h:21,
                 from ../examples/raytracer.cpp:47:
../src/../include/interface/agent.h:184:13: error: declaration of ‘double (* tag_laik_ext_profile_agent::gettime)()’ [-fpermissive]
     gettime gettime;
             ^~~~~~~
../src/../include/interface/agent.h:135:18: error: changes meaning of ‘gettime’ from ‘typedef double (* gettime)()’ [-fpermissive]
 typedef double (*gettime) (void);
                  ^~~~~~~
../src/../include/interface/agent.h:185:10: error: declaration of ‘int (* tag_laik_ext_profile_agent::peek)()’ [-fpermissive]
     peek peek;
          ^~~~
../src/../include/interface/agent.h:132:15: error: changes meaning of ‘peek’ from ‘typedef int (* peek)()’ [-fpermissive]
 typedef int (*peek) (void);
               ^~~~
```