### PR TITLE
examples/spmv2.c: Properly ifdef the "#pragma omp".

### DIFF
--- a/examples/spmv2.c
+++ b/examples/spmv2.c
@@ -272,7 +272,9 @@ int main(int argc, char* argv[])
             // my partition slice of result vector (local indexing, from 0)
             laik_map_def(resD, sNo, (void**) &res, &rcount);
 
+#ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic,50)
+#endif
             for(uint64_t r = fromRow; r < toRow; r++) {
                 res[r - fromRow] = 0.0;
                 for(int o = m->row[r]; o < m->row[r+1]; o++)


### PR DESCRIPTION
OpenMP may not be supported by the compiler or it may be supported but
explicitly disabled. Since some compilers then choke on the unknown #pragma,
hide it behind an ifdef.

See: http://bisqwit.iki.fi/story/howto/openmp/#Discussion