### PR TITLE
external/FT-STIM/laik-ext-fti.c: Fix warnings about signed/unsigend comparisons.

### DIFF
--- a/external/FT-STIM/laik-ext-fti.c
+++ b/external/FT-STIM/laik-ext-fti.c
@@ -116,7 +116,7 @@ performStep(
 ){
     LaikExtMsg msg;
     char buf[64];
-    int i;
+    unsigned int i;
     assert(step);
 
     msg.n_spare_nodes = 0;


### PR DESCRIPTION
Hi!

#27 enables a lot of additional warnings, but doesn't yet make them fatal, because a lot of code would trigger those warnings. This PR is an attempt to get rid of the first category of errors, ```-Wno-sign-compare```. I tried to guess as best as possible which variables should really be unsigned and which should really be signed, but I most likely got it wrong somewhere. So @weidendo and @twittidai, could you have a look and tell me what you think?

Best regards

Alex