### PR TITLE
.travis.yml: Stop installing the "uuid" and "uuid-dev" packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
 before_install:
   - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa -y
   - sudo apt-get -qq update
-  - sudo apt-get install -y openmpi-bin libopenmpi-dev libmosquitto-dev libprotobuf-c0-dev protobuf-c-compiler uuid uuid-dev libiomp5
+  - sudo apt-get install -y openmpi-bin libopenmpi-dev libmosquitto-dev libprotobuf-c0-dev protobuf-c-compiler libiomp5
   - sudo ln --symbolic /usr/lib/libiomp5.so.5 /usr/lib/libomp.so
   - mkdir $HOME/clang+llvm
   - export PATH=$HOME/clang+llvm/bin:$PATH


### PR DESCRIPTION
These are no longer needed, see #29.