### PR TITLE
configure: Use the correct environment variable when searching for a …

### DIFF
--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ else:
 
 cxx = ""
 if "CXX" in os.environ:
-    cxx = os.environ['CC']
+    cxx = os.environ['CXX']
 
 mycxx = cxx
 if not mycxx:


### PR DESCRIPTION
…C++ compiler.

Closes #55.