### PR TITLE
src/backends/tcp: Add the TCP backend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option (profiling-agent   "Enable profiling agent (needs libpapi-dev)"          
 option (simple-agent      "Enable simple agent"                                                         on)
 option (single-backend    "Enable Single backend"                                                       on)
 option (skip-missing      "Enable skipping optional features in the case of missing dependencies"       on)
+option (tcp-backend       "Enable TCP backend (needs libglib2.0-dev)"                                   on)
 
 # Add a pandoc helper function
 function (add_pandoc_target target)
@@ -81,3 +82,4 @@ add_subdirectory ("external/simple")
 add_subdirectory ("src")
 add_subdirectory ("tests")
 add_subdirectory ("tests/mpi")
+add_subdirectory ("tests/tcp")

--- a/include/laik-backend-tcp.h
+++ b/include/laik-backend-tcp.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "laik.h" // for Laik_Instance
+
+Laik_Instance* laik_init_tcp (int* argc, char*** argv);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,47 @@ if (single-backend)
     )
 endif ()
 
+# Optional TCP backend
+if (tcp-backend)
+    find_pkgconfig ("gio-2.0")
+    find_pkgconfig ("glib-2.0")
+
+    if (TARGET "gio-2.0" AND TARGET "glib-2.0")
+        message (STATUS "Dependency check for option 'tcp-backend' succeeded, building!")
+
+        target_sources ("laik"
+            PRIVATE
+                "backends/tcp/backend.c"
+                "backends/tcp/client.c"
+                "backends/tcp/config.c"
+                "backends/tcp/debug.c"
+                "backends/tcp/errors.c"
+                "backends/tcp/map.c"
+                "backends/tcp/messenger.c"
+                "backends/tcp/minimpi.c"
+                "backends/tcp/server.c"
+                "backends/tcp/socket.c"
+                "backends/tcp/task.c"
+        )
+
+        target_compile_definitions ("laik"
+            PRIVATE "GLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_48"
+            PRIVATE "GLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_48"
+            PRIVATE "LAIK_TCP_BACKEND_AVAILABLE"
+            # PRIVATE "LAIK_TCP_DEBUG"
+        )
+
+        target_link_libraries ("laik"
+            PRIVATE "gio-2.0"
+            PRIVATE "glib-2.0"
+        )
+    elseif (skip-missing)
+        message (STATUS "Dependency check for option 'tcp-backend' failed, skipping!")
+    else ()
+        message (FATAL_ERROR "Dependency check for option 'tcp-backend' failed, stopping!")
+    endif ()
+endif ()
+
 # Installation rules
 install (TARGETS "laik" DESTINATION "lib")
 

--- a/src/backends/tcp/backend.c
+++ b/src/backends/tcp/backend.c
@@ -1,0 +1,686 @@
+#include <glib.h>           // for g_malloc0_n, g_malloc, g_autoptr, g_new0
+#include <laik-internal.h>  // for _Laik_Data, _Laik_Group, redTOp, _Laik_Ma...
+#include <laik.h>           // for Laik_Data, Laik_Group, Laik_Mapping, Laik...
+#include <stdbool.h>        // for true, false, bool
+#include <stdint.h>         // for int64_t
+#include <stdio.h>          // for NULL, size_t, sprintf
+#include <string.h>         // for memcpy
+#include "debug.h"          // for laik_tcp_always
+#include "errors.h"         // for laik_tcp_errors_push, laik_tcp_errors_pre...
+#include "mpi.h"            // for MPI_Comm, MPI_Datatype, MPI_COMM_WORLD
+
+/* Type definitions */
+
+struct _Laik_TransitionPlan {
+    Laik_Data*       data;
+    Laik_Transition* transition;
+};
+
+/* Internal functions */
+
+static void laik_tcp_backend_push_code (Laik_Tcp_Errors* errors, int code) {
+    if (code != MPI_SUCCESS) {
+        char message[MPI_MAX_ERROR_STRING];
+        int length;
+
+        (void) MPI_Error_string (code, message, &length);
+
+        laik_tcp_errors_push (errors, __func__, 0, "An MPI operation failed, details below\n%s", message);
+    }
+}
+
+__attribute__ ((warn_unused_result))
+static MPI_Datatype laik_tcp_backend_get_mpi_type (const Laik_Data* data, Laik_Tcp_Errors* errors) {
+    laik_tcp_always (data);
+    laik_tcp_always (errors);
+
+    if (data->type == laik_Double) {
+        return MPI_DOUBLE;
+    }
+
+    if (data->type == laik_Float) {
+        return MPI_FLOAT;
+    }
+
+    laik_tcp_errors_push (errors, __func__, 0, "Unknown LAIK type: %s", data->type->name);
+    return 0;
+}
+
+__attribute__ ((warn_unused_result))
+static bool laik_tcp_backend_task_group_contains (const TaskGroup* group, const int task) {
+    // A null pointer shall mean "all tasks", so return a positive result
+    if (group == NULL) {
+        return true;
+    }
+
+    // Check if the the specified task is a member of the task group
+    for (int i = 0; i < group->count; i++) {
+        if (group->task[i] == task) {
+            return true;
+        }
+    }
+
+    // No luck, return a negative result
+    return false;
+}
+
+static void laik_tcp_backend_receive
+    ( const Laik_Data* data
+    , Laik_Mapping* output
+    , const Laik_Slice slice
+    , const int sender
+    , Laik_Tcp_Errors* errors
+    )
+{
+    laik_tcp_always (data);
+    laik_tcp_always (output);
+    laik_tcp_always (errors);
+
+    // Get our group
+    const Laik_Group* group = data->activePartitioning->group;
+
+    // Make sure we aren't talking to ourselves
+    laik_tcp_always (group->myid != sender);
+
+    // Make sure the mapping is ready to use
+    if (!output->base) {
+        laik_allocateMap (output, data->stat);
+    }
+
+    // Make sure the mapping supports deserialization
+    laik_tcp_always (output->layout->pack);
+
+    // Determine the MPI data type
+    const MPI_Datatype mpi_type = laik_tcp_backend_get_mpi_type (data, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to map LAIK data type to MPI data type");
+        return;
+    }
+
+    const MPI_Comm comm = *((MPI_Comm*) group->backend_data);
+    size_t elements = 0;
+
+    for (Laik_Index i = slice.from; !laik_index_isEqual (data->space->dims, &i, &(slice.to));) {
+        // Receive the next chunk of bytes
+        char buffer[1<<20];
+        MPI_Status status;
+        laik_tcp_backend_push_code (errors, MPI_Recv (buffer, sizeof (buffer) / data->elemsize, mpi_type, sender, 10, comm, &status));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 1, "Failed to receive MPI message from task %d", sender);
+            return;
+        }
+
+        // Determine how many logical elements we have received
+        int received;
+        laik_tcp_backend_push_code (errors, MPI_Get_count (&status, mpi_type, &received));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 2, "Failed to determine how many elements were received");
+            return;
+        }
+
+        // Unpack the received bytes
+        int unpacked = output->layout->unpack (output, &slice, &i, buffer, received * data->elemsize);
+
+        // Make sure that we unpacked everything
+        laik_tcp_always (received == unpacked);
+
+        elements += unpacked;
+    }
+
+    laik_tcp_always (elements == laik_slice_size (data->space->dims, &slice));
+
+    // Update the statistics
+    if (data->stat) {
+        data->stat->recvCount++;
+        data->stat->receivedBytes += elements * data->elemsize;
+    }
+}
+
+static void laik_tcp_backend_send
+    ( const Laik_Data* data
+    , const Laik_Mapping* input
+    , const Laik_Slice slice
+    , const int receiver
+    , Laik_Tcp_Errors* errors
+    )
+{
+    laik_tcp_always (data);
+    laik_tcp_always (input);
+    laik_tcp_always (errors);
+
+    // Get our group
+    const Laik_Group* group = data->activePartitioning->group;
+
+    // Make sure we aren't talking to ourselves
+    laik_tcp_always (group->myid != receiver);
+
+    // Make sure the mapping is ready to use
+    laik_tcp_always (input->base);
+
+    // Make sure the mapping supports serialization
+    laik_tcp_always (input->layout->pack);
+
+    // Determine the MPI data type
+    const MPI_Datatype mpi_type = laik_tcp_backend_get_mpi_type (data, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to map LAIK data type to MPI data type");
+        return;
+    }
+
+    const MPI_Comm comm = *((MPI_Comm*) group->backend_data);
+    size_t elements = 0;
+
+    for (Laik_Index i = slice.from; !laik_index_isEqual (data->space->dims, &i, &(slice.to));) {
+        // Pack the next chunk
+        char buffer[1<<20];
+        int packed = input->layout->pack (input, &slice, &i, buffer, sizeof (buffer));
+        laik_tcp_always (packed > 0);
+
+        // Send the next chunk
+        laik_tcp_backend_push_code (errors, MPI_Send (buffer, packed, mpi_type, receiver, 10, comm));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 1, "Failed to send MPI message to task %d", receiver);
+            return;
+        }
+
+        elements += packed;
+    }
+
+    laik_tcp_always (elements == laik_slice_size (data->space->dims, &slice));
+
+    // Update the statistics
+    if (data->stat) {
+        data->stat->sendCount++;
+        data->stat->sentBytes += elements * data->elemsize;
+    }
+}
+
+__attribute__ ((warn_unused_result))
+static bool laik_tcp_backend_native_reduce
+    ( const MPI_Comm communicator
+    , const MPI_Datatype mpi_type
+    , const TaskGroup* input_group
+    , const TaskGroup* output_group
+    , const Laik_ReductionOperation op
+    , const void* input_buffer
+    , void* output_buffer
+    , const int elements
+    , Laik_Tcp_Errors* errors
+    )
+{
+    laik_tcp_always (errors);
+
+    MPI_Op mpi_operation;
+    switch (op) {
+        case LAIK_RO_Sum:
+            mpi_operation = MPI_SUM;
+            break;
+        default:
+            return false;
+    }
+
+    if (input_group == NULL && output_group == NULL) {
+        if (input_buffer == output_buffer) {
+            input_buffer = MPI_IN_PLACE;
+        }
+
+        laik_tcp_backend_push_code (errors, MPI_Allreduce (input_buffer, output_buffer, elements, mpi_type, mpi_operation, communicator));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 1, "Failed to run MPI_Allreduce");
+            return false;
+        }
+
+        return true;
+    } else if (input_group == NULL && output_group && output_group->count == 1) {
+        if (input_buffer == output_buffer) {
+            input_buffer = MPI_IN_PLACE;
+        }
+
+        laik_tcp_backend_push_code (errors, MPI_Reduce (input_buffer, output_buffer, elements, mpi_type, mpi_operation, output_group->task[0], communicator));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 2, "Failed to run MPI_Reduce");
+            return false;
+        }
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static void laik_tcp_backend_reduce
+    ( const Laik_Data* data
+    , const TaskGroup* input_group
+    , const TaskGroup* output_group
+    , const Laik_Mapping* input_mapping
+    , Laik_Mapping* output_mapping
+    , const struct redTOp* op
+    , Laik_Tcp_Errors* errors
+    )
+{
+    laik_tcp_always (data);
+    laik_tcp_always (op);
+    laik_tcp_always (errors);
+
+    laik_tcp_always (data->space->dims == 1);
+
+    // Determine the MPI data type
+    const MPI_Datatype mpi_type = laik_tcp_backend_get_mpi_type (data, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to map LAIK data type to MPI data type");
+        return;
+    }
+
+    const Laik_Group*   group        = data->activePartitioning->group;
+    const MPI_Comm      communicator = *((MPI_Comm*) group->backend_data);
+    const size_t        elements     = op->slc.to.i[0] - op->slc.from.i[0];
+    const size_t        bytes        = elements * data->elemsize;
+
+    laik_tcp_always (group->myid >= 0);
+
+    char* input_buffer = NULL;
+    if (input_mapping) {
+        laik_tcp_always (op->slc.from.i[0] >= input_mapping->requiredSlice.from.i[0]);
+        input_buffer = input_mapping->base + (op->slc.from.i[0] - input_mapping->requiredSlice.from.i[0]) * data->elemsize;
+    }
+
+    char* output_buffer = NULL;
+    if (output_mapping) {
+        if (output_mapping->base == NULL) {
+            laik_allocateMap (output_mapping, data->stat);
+        }
+
+        laik_tcp_always (op->slc.from.i[0] >= output_mapping->requiredSlice.from.i[0]);
+
+        output_buffer = output_mapping->base + (op->slc.from.i[0] - output_mapping->requiredSlice.from.i[0]) * data->elemsize;
+    }
+
+    const bool native_reduce = laik_tcp_backend_native_reduce (communicator, mpi_type, input_group, output_group, op->redOp, input_buffer, output_buffer, elements, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 1, "Failed to do native reduce");
+        return;
+    }
+
+    if (!native_reduce) {
+        // Let one task from the output group to do the reduction for everybody.
+        int reduction_task = -1;
+        for (int task = 0; task < group->size; task++) {
+            if (laik_tcp_backend_task_group_contains (output_group, task)) {
+                reduction_task = task;
+                break;
+            }
+        }
+        laik_tcp_always (reduction_task >= 0);
+
+        if (reduction_task == group->myid) {
+            // Allocate a buffer where MPI_Recv can store the reduce data from
+            // the other tasks. Using a smaller buffer would mean we have to do
+            // do multiple MPI_Recv calls, so we essentially chose speed over
+            // memory consumption here.
+            g_autofree void* receive_buffer = g_malloc (bytes);
+
+            // Allocate a buffer where we can incrementally construct the result
+            // of the reduction. We can't use the output buffer here, since it
+            // may point to the same memory as the input buffer and we don't
+            // want to enforce that the local data must always the first element
+            // in the reduction.
+            g_autofree void* result_buffer = g_malloc (bytes);
+
+            // Keep track of whether we already have a base element and can
+            // therefore do a reduce operation with a new element.
+            bool have_base_element = false;
+
+            // Iterate over our the tasks in our group in order...
+            for (int sender = 0; sender < group->size; sender++) {
+                // ... and include the data from all tasks which have been
+                // marked as input tasks for this reduction.
+                if (laik_tcp_backend_task_group_contains (input_group, sender)) {
+                    if (sender == group->myid) {
+                        if (have_base_element) {
+                            data->type->reduce (result_buffer, result_buffer, input_buffer, elements, op->redOp);
+                        } else {
+                            memcpy (result_buffer, input_buffer, bytes);
+                            have_base_element = true;
+                        }
+                    } else {
+                        if (have_base_element) {
+                            MPI_Status status;
+
+                            laik_tcp_backend_push_code (errors, MPI_Recv (receive_buffer, elements, mpi_type, sender, 11, communicator, &status));
+                            if (laik_tcp_errors_present (errors)) {
+                                laik_tcp_errors_push (errors, __func__, 2, "Failed to receive reduction input from task %d", sender);
+                                return;
+                            }
+
+                            data->type->reduce (result_buffer, result_buffer, receive_buffer, elements, op->redOp);
+                        } else {
+                            MPI_Status status;
+
+                            laik_tcp_backend_push_code (errors, MPI_Recv (result_buffer, elements, mpi_type, sender, 11, communicator, &status));
+                            if (laik_tcp_errors_present (errors)) {
+                                laik_tcp_errors_push (errors, __func__, 3, "Failed to receive reduction input from task %d", sender);
+                                return;
+                            }
+
+                            have_base_element = true;
+                        }
+                    }
+                }
+            }
+
+            // Check that we wrote to the result buffer at least once and
+            // then copy it to the output buffer.
+            laik_tcp_always (have_base_element);
+            memcpy (output_buffer, result_buffer, bytes);
+
+            // Send the reduction result to all the tasks in the output group.
+            for (int receiver = 0; receiver < group->size; receiver++) {
+                if (receiver != group->myid && laik_tcp_backend_task_group_contains (output_group, receiver)) {
+                    laik_tcp_backend_push_code (errors, MPI_Send (output_buffer, elements, mpi_type, receiver, 12, communicator));
+                    if (laik_tcp_errors_present (errors)) {
+                        laik_tcp_errors_push (errors, __func__, 4, "Failed to send out reduction result back to task %d", reduction_task);
+                        return;
+                    }
+                }
+            }
+        } else {
+            if (input_mapping) {
+                laik_tcp_backend_push_code (errors, MPI_Send (input_buffer, elements, mpi_type, reduction_task, 11, communicator));
+                if (laik_tcp_errors_present (errors)) {
+                    laik_tcp_errors_push (errors, __func__, 5, "Failed to send MPI message to reduction task %d", reduction_task);
+                    return;
+                }
+            }
+
+            if (output_mapping) {
+                MPI_Status status;
+                laik_tcp_backend_push_code (errors, MPI_Recv (output_buffer, elements, mpi_type, reduction_task, 12, communicator, &status));
+                if (laik_tcp_errors_present (errors)) {
+                    laik_tcp_errors_push (errors, __func__, 6, "Failed to receive MPI message from reduction task %d", reduction_task);
+                    return;
+                }
+            }
+        }
+    }
+
+    // Update the statistics
+    if (data->stat) {
+        data->stat->reduceCount++;
+        data->stat->reducedBytes += bytes;
+    }
+}
+
+/* API functions */
+
+static void laik_tcp_backend_cleanup (Laik_TransitionPlan* plan) {
+    // Check the parameters
+    laik_tcp_always (plan);
+
+    g_free (plan);
+}
+
+static void laik_tcp_backend_exec
+    ( Laik_Data* data
+    , Laik_Transition* transition
+    , Laik_TransitionPlan* plan
+    , Laik_MappingList* input_list
+    , Laik_MappingList* output_list
+    )
+{
+    laik_tcp_always (data);
+    laik_tcp_always (transition);
+
+    if (plan) {
+        laik_tcp_always (data       == plan->data);
+        laik_tcp_always (transition == plan->transition);
+    }
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const Laik_Group* group = data->activePartitioning->group;
+
+    for (int i = 0; i < transition->redCount; i++) {
+        const struct redTOp* op = transition->red + i;
+
+        TaskGroup* input_group = NULL;
+        if (op->inputGroup >= 0) {
+            laik_tcp_always (op->inputGroup < transition->subgroupCount);
+            input_group = transition->subgroup + op->inputGroup;
+        }
+
+        TaskGroup* output_group = NULL;
+        if (op->outputGroup >= 0) {
+            laik_tcp_always (op->outputGroup < transition->subgroupCount);
+            output_group = transition->subgroup + op->outputGroup;
+        }
+
+        Laik_Mapping* input_mapping = NULL;
+        if (laik_tcp_backend_task_group_contains (input_group, group->myid)) {
+            laik_tcp_always (input_list);
+            laik_tcp_always (op->myInputMapNo  >= 0 && op->myInputMapNo  < input_list->count);
+            input_mapping = input_list->map + op->myInputMapNo;
+        }
+
+        Laik_Mapping* output_mapping = NULL;
+        if (laik_tcp_backend_task_group_contains (output_group, group->myid)) {
+            laik_tcp_always (output_list);
+            laik_tcp_always (op->myOutputMapNo >= 0 && op->myOutputMapNo < output_list->count);
+            output_mapping = output_list->map + op->myOutputMapNo;
+        }
+
+        laik_tcp_backend_reduce (data, input_group, output_group, input_mapping, output_mapping, op, errors);
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 0, "Reduce operation failed");
+            laik_tcp_errors_abort (errors);
+        }
+    }
+
+    for (int sender = 0; sender < group->size; sender++) {
+        if (sender == group->myid) {
+            // It's our turn to send data, so do all our send operations.
+            for (int i = 0; i < transition->sendCount; i++) {
+                const struct sendTOp* op = transition->send + i;
+
+                laik_tcp_always (input_list);
+                laik_tcp_always (op->mapNo >= 0 && op->mapNo < input_list->count);
+
+                laik_tcp_backend_send (data, input_list->map + op->mapNo    , op->slc, op->toTask, errors);
+                if (laik_tcp_errors_present (errors)) {
+                    laik_tcp_errors_push (errors, __func__, 1, "Send operation failed");
+                    laik_tcp_errors_abort (errors);
+                }
+            }
+        } else {
+            // It's not our turn to send data, instead we should receive from
+            // the current "sender" task.
+            for (int i = 0; i < transition->recvCount; i++) {
+                const struct recvTOp* op = transition->recv + i;
+
+                if (sender == op->fromTask) {
+                    laik_tcp_always (output_list);
+                    laik_tcp_always (op->mapNo >= 0 && op->mapNo < output_list->count);
+
+                    laik_tcp_backend_receive (data, output_list->map + op->mapNo, op->slc, op->fromTask, errors);
+                    if (laik_tcp_errors_present (errors)) {
+                        laik_tcp_errors_push (errors, __func__, 2, "Receive operation failed");
+                        laik_tcp_errors_abort (errors);
+                    }
+                }
+            }
+        }
+    }
+}
+
+static void laik_tcp_backend_finalize () {
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    // Finalize the MPI subsystem if necessary
+    int mpi_is_initialized;
+    laik_tcp_backend_push_code (errors, MPI_Initialized (&mpi_is_initialized));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine whether the MPI subsystem is initialized");
+        laik_tcp_errors_abort (errors);
+    }
+
+    if (mpi_is_initialized) {
+        laik_tcp_backend_push_code (errors, MPI_Finalize());
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 1, "Failed to finalize the MPI subsystem");
+            laik_tcp_errors_abort (errors);
+        }
+    }
+}
+
+static Laik_TransitionPlan* laik_tcp_backend_prepare (Laik_Data* data, Laik_Transition* transition) {
+    laik_tcp_always (data);
+    laik_tcp_always (transition);
+
+    // Allocate a plan object
+    Laik_TransitionPlan* plan = g_new0 (Laik_TransitionPlan, 1);
+
+    // Fill the plan object
+    plan->data       = data;
+    plan->transition = transition;
+
+    // Return the plan object
+    return plan;
+}
+
+static bool laik_tcp_backend_probe (Laik_TransitionPlan* plan, const int map_number) {
+    laik_tcp_always (plan);
+
+    (void) plan;
+    (void) map_number;
+
+    return true;
+}
+
+static void laik_tcp_backend_sync (Laik_Instance* instance) {
+    laik_tcp_always (instance);
+
+    (void) instance;
+}
+
+static void laik_tcp_backend_update_group (Laik_Group* group) {
+    laik_tcp_always (group);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    // We are transitioning from an old (parent) group to a new (child) group,
+    // so run a few checks to detect programming errors:
+
+    // 1. The new group must actually have a parent group.
+    laik_tcp_always (group->parent);
+
+    // 2. The parent group must have its backend_data set up properly.
+    laik_tcp_always (group->parent->backend_data);
+
+    // 3. The new (child) group must have no backend_data set yet.
+    laik_tcp_always (group->backend_data == NULL);
+
+    // Everything is fine, so allocate memory for our new group's backend_data.
+    group->backend_data = g_new0 (MPI_Comm, 1);
+
+    // Run MPI_Comm_split to transition from the old (parent) group's
+    // communicator to a new communicator used by the new (child) group.
+    // The current task will be part of the new communicator iff its ID is >= 0
+    // and it will be ranked according to its ID (this means LAIK ID == MPI ID).
+    laik_tcp_backend_push_code (errors, MPI_Comm_split (* ((MPI_Comm*) group->parent->backend_data), group->myid < 0 ? MPI_UNDEFINED : 0, group->myid, group->backend_data));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to split communicator for updated group");
+        laik_tcp_errors_abort (errors);
+    }
+}
+
+static void laik_tcp_backend_wait (Laik_TransitionPlan* plan, const int map_number) {
+    laik_tcp_always (plan);
+
+    (void) plan;
+    (void) map_number;
+}
+
+/* Public functions */
+
+Laik_Instance* laik_init_tcp (int* argc, char*** argv) {
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    // Prepare our Laik_Backend struct which contains all the function pointers
+    static const Laik_Backend backend = {
+        .cleanup     = laik_tcp_backend_cleanup,
+        .exec        = laik_tcp_backend_exec,
+        .finalize    = laik_tcp_backend_finalize,
+        .name        = "TCP Backend",
+        .prepare     = laik_tcp_backend_prepare,
+        .probe       = laik_tcp_backend_probe,
+        .sync        = laik_tcp_backend_sync,
+        .updateGroup = laik_tcp_backend_update_group,
+        .wait        = laik_tcp_backend_wait,
+    };
+
+    // Determine if the MPI subsystem is already initialized
+    int mpi_is_initialized;
+    laik_tcp_backend_push_code (errors, MPI_Initialized (&mpi_is_initialized));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine whether the MPI subsystem is initialized");
+        laik_tcp_errors_abort (errors);
+    }
+
+    // Initialize the MPI subsystem if necessary
+    if (!mpi_is_initialized) {
+        laik_tcp_backend_push_code (errors, MPI_Init (argc, argv));
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_errors_push (errors, __func__, 1, "Failed to initialize the MPI subsystem");
+            laik_tcp_errors_abort (errors);
+        }
+    }
+
+    // Determine the name of our processor
+    char name[MPI_MAX_PROCESSOR_NAME];
+    int length;
+    laik_tcp_backend_push_code (errors, MPI_Get_processor_name (name, &length));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 2, "Failed to determine the MPI processor name");
+        laik_tcp_errors_abort (errors);
+    }
+
+    // Determine our ID in the MPI world
+    int myid;
+    laik_tcp_backend_push_code (errors, MPI_Comm_rank (MPI_COMM_WORLD, &myid));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 3, "Failed to determine our rank in the MPI world");
+        laik_tcp_errors_abort (errors);
+    }
+
+    // Determine the size of the MPI world
+    int size;
+    laik_tcp_backend_push_code (errors, MPI_Comm_size (MPI_COMM_WORLD, &size));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 4, "Failed to determine the size of the MPI world");
+        laik_tcp_errors_abort (errors);
+    }
+
+    // Create a new, private MPI communicator for the instance.
+    MPI_Comm* instance_communicator = g_new0 (MPI_Comm, 1);
+    laik_tcp_backend_push_code (errors, MPI_Comm_dup (MPI_COMM_WORLD, instance_communicator));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 5, "Failed to duplicate MPI_COMM_WORLD for instance");
+        laik_tcp_errors_abort (errors);
+    }
+
+    // Create a new, private MPI communicator for the first group.
+    MPI_Comm* group_communicator = g_new0 (MPI_Comm, 1);
+    laik_tcp_backend_push_code (errors, MPI_Comm_dup (MPI_COMM_WORLD, group_communicator));
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 6, "Failed to duplicate MPI_COMM_WORLD for group");
+        laik_tcp_errors_abort (errors);
+    }
+ 
+    // Create the instance.
+    Laik_Instance* instance = laik_new_instance (&backend, size, myid, name, instance_communicator, group_communicator);
+
+    // Set up the instance GUID.
+    sprintf (instance->guid, "%d", myid);
+
+    // Return the instance
+    return instance;
+}

--- a/src/backends/tcp/client.c
+++ b/src/backends/tcp/client.c
@@ -1,0 +1,94 @@
+#include "client.h"
+#include <glib.h>     // for g_hash_table_size, g_free, g_hash_table_new_full
+#include <stdbool.h>  // for false, true
+#include <stddef.h>   // for NULL, size_t
+#include <stdint.h>   // for int64_t
+#include "debug.h"    // for laik_tcp_debug
+#include "errors.h"   // for laik_tcp_always, laik_tcp_errors_new, Laik_Tcp_...
+#include "socket.h"   // for Laik_Tcp_Socket, laik_tcp_socket_destroy, laik_...
+
+struct Laik_Tcp_Client {
+    GHashTable* connections;
+    size_t      limit;
+};
+
+static int laik_tcp_client_too_old (void* key, void* value, void* userdata) {
+    laik_tcp_always (key);
+    laik_tcp_always (value);
+    laik_tcp_always (userdata);
+
+    __attribute__ ((unused))
+    const char*            peer       = key;
+    const Laik_Tcp_Socket* connection = value;
+    const int64_t          timestamp  = * (int64_t*) userdata;
+
+    if (laik_tcp_socket_get_timestamp (connection) < timestamp) {
+        laik_tcp_debug ("Removing connection to %s because its timestamp is too old", peer);
+        return true;
+    }
+
+    return false;
+}
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_client_connect (Laik_Tcp_Client* this, const char* address) {
+    laik_tcp_always (this);
+    laik_tcp_always (address);
+
+    char*            stored_address = NULL;
+    Laik_Tcp_Socket* connection     = NULL;
+
+    // Check if we already have a connection to this address
+    if (g_hash_table_lookup_extended (this->connections, address, (void**) &stored_address, (void**) &connection)) {
+        g_hash_table_steal (this->connections, address);
+        g_free (stored_address);
+        return connection;
+    } else {
+        g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+        return laik_tcp_socket_new (LAIK_TCP_SOCKET_TYPE_CLIENT, address, errors);
+    }
+}
+
+void laik_tcp_client_free (Laik_Tcp_Client* this) {
+    if (!this) {
+        return;
+    }
+
+    g_hash_table_unref (this->connections);
+
+    g_free (this);
+}
+
+Laik_Tcp_Client* laik_tcp_client_new (size_t limit) {
+    Laik_Tcp_Client* this = g_new0 (Laik_Tcp_Client, 1);
+
+    *this = (Laik_Tcp_Client) {
+        .connections = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, laik_tcp_socket_destroy),
+        .limit       = limit,
+    };
+
+    return this;
+}
+
+void laik_tcp_client_store (Laik_Tcp_Client* this, const char* address, Laik_Tcp_Socket* socket) {
+    laik_tcp_always (this);
+    laik_tcp_always (address);
+    laik_tcp_always (socket);
+
+    laik_tcp_debug ("Size before = %u/%zu", g_hash_table_size (this->connections), this->limit);
+
+    if (g_hash_table_size (this->connections) >= this->limit) {
+        int64_t timestamp = g_get_monotonic_time () - G_TIME_SPAN_SECOND;
+        g_hash_table_foreach_remove (this->connections, laik_tcp_client_too_old, &timestamp);
+    }
+
+    if (g_hash_table_size (this->connections) < this->limit) {
+        laik_tcp_debug ("Found a free slot insert connection to %s, keeping", address);
+        g_hash_table_insert (this->connections, g_strdup (address), laik_tcp_socket_touch (socket));
+    } else {
+        laik_tcp_debug ("Could not find a free slot to insert connection to %s, releasing", address);
+        laik_tcp_socket_free (socket);
+    }
+
+    laik_tcp_debug ("Size after = %u/%zu", g_hash_table_size (this->connections), this->limit);
+}

--- a/src/backends/tcp/client.h
+++ b/src/backends/tcp/client.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <glib.h>    // for G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stddef.h>  // for size_t
+#include "socket.h"  // for Laik_Tcp_Socket
+
+typedef struct Laik_Tcp_Client Laik_Tcp_Client;
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_client_connect (Laik_Tcp_Client* this, const char* address);
+
+void laik_tcp_client_free (Laik_Tcp_Client* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Client, laik_tcp_client_free)
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Client* laik_tcp_client_new (size_t limit);
+
+void laik_tcp_client_store (Laik_Tcp_Client* this, const char* address, Laik_Tcp_Socket* socket);

--- a/src/backends/tcp/config.c
+++ b/src/backends/tcp/config.c
@@ -1,0 +1,183 @@
+#include "config.h"
+#include <gio/gio.h>  // for g_file_load_contents, g_file_new_for_commandlin...
+#include <glib.h>     // for g_ptr_array_add, g_strdup_printf, g_autoptr
+#include <stdbool.h>  // for false, bool, true
+#include <stdint.h>   // for int64_t
+#include <stdlib.h>   // for getenv, NULL, atol, size_t
+#include <unistd.h>   // for getppid, getpid
+#include "debug.h"    // for laik_tcp_always, laik_tcp_debug
+#include "errors.h"   // for laik_tcp_errors_present, laik_tcp_errors_new
+
+static GMutex           mutex;
+static Laik_Tcp_Config* config    = NULL;
+static int64_t          timestamp = 0;
+static GThread*         thread    = NULL;
+static bool             running   = false;
+
+__attribute__ ((warn_unused_result))
+static GKeyFile* laik_tcp_config_keyfile (Laik_Tcp_Errors* errors) {
+    laik_tcp_always (errors);
+
+    GError* error = NULL;
+
+    // If the environment variable is set, load the configuration file from it
+    const char* location = getenv ("LAIK_TCP_CONFIG");
+    if (!location) {
+        return NULL;
+    }
+
+    // Load the configuration file from a path or URL via GIO auto-magic
+    g_autoptr (GFile) file = g_file_new_for_commandline_arg (location);
+    g_autofree char* data = NULL;
+    size_t size = 0;
+    g_file_load_contents (file, NULL, &data, &size, NULL, &error);
+    if (error) {
+        laik_tcp_errors_push_direct (errors, error);
+        return NULL;
+    }
+
+    // Parse the configuration file as a GKeyFile
+    g_autoptr (GKeyFile) keyfile = g_key_file_new ();
+    g_key_file_load_from_data (keyfile, data, size, G_KEY_FILE_NONE, &error);
+    if (error) {
+        laik_tcp_errors_push_direct (errors, error);
+        return NULL;
+    }
+
+    // Return the keyfile
+    return g_steal_pointer (&keyfile);
+}
+
+__attribute__ ((warn_unused_result))
+static Laik_Tcp_Config* laik_tcp_config_new (Laik_Tcp_Errors* errors) {
+    laik_tcp_always (errors);
+
+    // Try to load the configuration file
+    g_autoptr (GKeyFile) keyfile = laik_tcp_config_keyfile (errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to parse the configuration file");
+        return NULL;
+    }
+
+    // Try to read the address mapping from the configuration file
+    g_autoptr (GPtrArray) addresses = g_ptr_array_new_with_free_func (g_free);
+    if (keyfile && g_key_file_has_key (keyfile, "addresses", "0", NULL)) {
+        for (size_t task = 0; ; task++) {
+            g_autofree char* key = g_strdup_printf ("%zu", task);
+            char* value = g_key_file_get_string (keyfile, "addresses", key, NULL);
+            if (value) {
+                g_ptr_array_add (addresses, value);
+            } else {
+                break;
+            }
+        }
+    } else if (getenv ("OMPI_COMM_WORLD_SIZE") && atol (getenv ("OMPI_COMM_WORLD_SIZE")) > 0) {
+        const size_t size = atol (getenv ("OMPI_COMM_WORLD_SIZE"));
+        for (size_t task = 0; task < size; task++) {
+           g_ptr_array_add (addresses, g_strdup_printf ("laik-tcp-auto-openmpi-%zu-%zu", (size_t) getppid (), task));
+        }
+    } else if (getenv ("PMI_SIZE") && atol (getenv ("PMI_SIZE")) > 0) {
+        const size_t size = atol (getenv ("PMI_SIZE"));
+        for (size_t task = 0; task < size; task++) {
+           g_ptr_array_add (addresses, g_strdup_printf ("laik-tcp-auto-mpich-%zu-%zu", (size_t) getppid (), task));
+        }
+    } else {
+        g_ptr_array_add (addresses, g_strdup_printf ("laik-tcp-auto-single-%zu", (size_t) getpid ()));
+    }
+
+    // Create the object
+    Laik_Tcp_Config* this = g_new0 (Laik_Tcp_Config, 1);
+
+    // Initialize the object
+    *this = (Laik_Tcp_Config) {
+        .addresses  = g_steal_pointer (&addresses),
+        .references = 1,
+    };
+
+    // Return the object
+    return this;
+}
+
+static void* laik_tcp_config_update (void* data) {
+    // Try to construct a new configuration object
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+    g_autoptr (Laik_Tcp_Config) update = laik_tcp_config_new (errors);
+
+    // Take the lock
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (&mutex);
+
+    // If we got a new configuration object, replace the old one
+    if (!laik_tcp_errors_present (errors)) {
+        laik_tcp_config_unref (config);
+        config = g_steal_pointer (&update);
+    }
+
+    // We are done and ready to be reaped
+    running = false;
+
+    // Avoid a warning about the "data" variable being unused
+    return data;
+}
+
+Laik_Tcp_Config* laik_tcp_config () {
+    // Take the lock
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (&mutex);
+
+    // If we don't have a configuration yet, try to get it a number of times
+    for (size_t try = 0; config == NULL; try++) {
+        g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+        config = laik_tcp_config_new (errors);
+
+        if (laik_tcp_errors_present (errors)) {
+            if (try < 10) {
+                g_usleep (100 * G_TIME_SPAN_MILLISECOND);
+            } else {
+                laik_tcp_errors_push (errors, __func__, 0, "Failed to construct the initial configuration object for the 10th time");
+                laik_tcp_errors_abort (errors);
+            }
+        }
+    }
+
+    // If a thread was started and has finished in the mean time, reap it here
+    if (thread && !running) {
+        laik_tcp_debug ("Update thread completed, reaping its result value");
+        (void) g_thread_join (thread);
+        thread = NULL;
+    }
+
+    // If no configuration update is running but its overdue, start it
+    if (!running && g_get_monotonic_time () - timestamp > G_TIME_SPAN_SECOND) {
+        laik_tcp_debug ("Configuration outdated, starting update");
+        running   = true;
+        timestamp = g_get_monotonic_time ();
+        thread    = g_thread_new ("Update Thread", laik_tcp_config_update, NULL);
+    }
+
+    // Return the current configuration
+    return laik_tcp_config_ref (config);
+}
+
+Laik_Tcp_Config* laik_tcp_config_ref (Laik_Tcp_Config* this) {
+    laik_tcp_always (this);
+
+    g_atomic_int_inc (&this->references);
+
+    return this;
+}
+
+void laik_tcp_config_unref (Laik_Tcp_Config* this) {
+    if (!this) {
+        return;
+    }
+
+    if (!g_atomic_int_dec_and_test (&this->references)) {
+        return;
+    }
+
+    g_ptr_array_unref (this->addresses);
+
+    g_free (this);
+}

--- a/src/backends/tcp/config.h
+++ b/src/backends/tcp/config.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <glib.h>  // for GPtrArray, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+
+typedef struct {
+    GPtrArray* addresses;
+
+    int references;
+} Laik_Tcp_Config;
+
+Laik_Tcp_Config* laik_tcp_config ();
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Config* laik_tcp_config_ref (Laik_Tcp_Config* this);
+
+void laik_tcp_config_unref (Laik_Tcp_Config* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Config, laik_tcp_config_unref)

--- a/src/backends/tcp/debug.c
+++ b/src/backends/tcp/debug.c
@@ -1,0 +1,18 @@
+#include "debug.h"
+#include <glib.h>    // for g_strdup_vprintf, g_autofree
+#include <stdarg.h>  // for va_end, va_list, va_start
+#include <stdio.h>   // for fprintf, stderr
+#include <unistd.h>  // for getpid
+
+void laik_tcp_debug_real (const char* function, int line, const char* format, ...) {
+    laik_tcp_always (function);
+    laik_tcp_always (format);
+
+    va_list arguments;
+
+    va_start (arguments, format);
+    g_autofree const char* message = g_strdup_vprintf (format, arguments);
+    va_end (arguments);
+
+    fprintf (stderr, "%5d\t%35s\t%5d\t%s\n", getpid (), function, line, message);
+}

--- a/src/backends/tcp/debug.h
+++ b/src/backends/tcp/debug.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <assert.h>  // for assert
+
+#ifdef LAIK_TCP_DEBUG
+#define laik_tcp_always(...) assert (__VA_ARGS__)
+#define laik_tcp_debug(...) laik_tcp_debug_real (__func__, __LINE__, __VA_ARGS__)
+#else
+#define laik_tcp_always(...)
+#define laik_tcp_debug(...)
+#endif
+
+__attribute__ ((format (printf, 3, 4)))
+void laik_tcp_debug_real (const char* function, int line, const char* format, ...);

--- a/src/backends/tcp/errors.c
+++ b/src/backends/tcp/errors.c
@@ -1,0 +1,89 @@
+#include "errors.h"
+#include <glib.h>    // for GError, g_quark_from_string, g_queue_push_head
+#include <stdarg.h>  // for va_end, va_list, va_start
+#include <stdio.h>   // for fflush, fprintf, NULL, stderr
+#include <stdlib.h>  // for abort
+#include "debug.h"   // for laik_tcp_always
+
+static void laik_tcp_errors_show1 (void* data, void* userdata) {
+    laik_tcp_always (data);
+    laik_tcp_always (userdata);
+
+    GError*  error  = data;
+    GString* string = userdata;
+
+    g_string_append_printf (string, " => Domain %s encountered error #%d: %s\n", g_quark_to_string (error->domain), error->code, error->message);
+}
+
+void laik_tcp_errors_abort (Laik_Tcp_Errors* this) {
+    laik_tcp_always (this);
+
+    fprintf (stderr, "[LAIK TCP Backend] Aborting, the contents of the error stack follow:\n%s", laik_tcp_errors_show (this));
+    fflush (stderr);
+
+    abort ();
+}
+
+void laik_tcp_errors_clear (Laik_Tcp_Errors* this) {
+    laik_tcp_always (this);
+
+    GError* error = NULL;
+
+    while ((error = g_queue_pop_head (this))) {
+        g_error_free (error);
+    }
+}
+
+void laik_tcp_errors_free (Laik_Tcp_Errors* this) {
+    if (!this) {
+        return;
+    }
+
+    laik_tcp_errors_clear (this);
+
+    g_queue_free (this);
+}
+
+Laik_Tcp_Errors* laik_tcp_errors_new (void) {
+    return g_queue_new ();
+}
+
+bool laik_tcp_errors_matches (Laik_Tcp_Errors* this, const char* domain, int code) {
+    laik_tcp_always (this);
+    laik_tcp_always (domain);
+
+    return g_error_matches (g_queue_peek_head (this), g_quark_from_string (domain), code);
+}
+
+bool laik_tcp_errors_present (Laik_Tcp_Errors* this) {
+    laik_tcp_always (this);
+
+    return !g_queue_is_empty (this);
+}
+
+void laik_tcp_errors_push (Laik_Tcp_Errors* this, const char* domain, int code, const char* format, ...) {
+    laik_tcp_always (this);
+    laik_tcp_always (domain);
+    laik_tcp_always (format);
+
+    va_list arguments;
+
+    va_start (arguments, format);
+    g_queue_push_head (this, g_error_new_valist (g_quark_from_string (domain), code, format, arguments));
+    va_end (arguments);
+}
+
+void laik_tcp_errors_push_direct (Laik_Tcp_Errors* this, GError* error) {
+    laik_tcp_always (this);
+    laik_tcp_always (error);
+
+    g_queue_push_head (this, error);
+}
+
+char* laik_tcp_errors_show (Laik_Tcp_Errors* this) {
+    GString* result = g_string_new (NULL);
+
+    g_queue_foreach (this, laik_tcp_errors_show1, result);
+
+    return g_string_free (result, false);
+}

--- a/src/backends/tcp/errors.h
+++ b/src/backends/tcp/errors.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <glib.h>     // for GError, GQueue, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stdbool.h>  // for bool
+
+typedef GQueue Laik_Tcp_Errors;
+
+__attribute__ ((noreturn))
+void laik_tcp_errors_abort (Laik_Tcp_Errors* this);
+
+void laik_tcp_errors_clear (Laik_Tcp_Errors* this);
+
+void laik_tcp_errors_free (Laik_Tcp_Errors* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Errors, laik_tcp_errors_free)
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Errors* laik_tcp_errors_new (void);
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_errors_matches (Laik_Tcp_Errors* this, const char* domain, int code);
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_errors_present (Laik_Tcp_Errors* this);
+
+__attribute__ ((format (printf, 4, 5)))
+void laik_tcp_errors_push (Laik_Tcp_Errors* this, const char* domain, int code, const char* format, ...);
+
+void laik_tcp_errors_push_direct (Laik_Tcp_Errors* this, GError* error);
+
+__attribute__ ((warn_unused_result))
+char* laik_tcp_errors_show (Laik_Tcp_Errors* this);

--- a/src/backends/tcp/map.c
+++ b/src/backends/tcp/map.c
@@ -1,0 +1,191 @@
+#include "map.h"
+#include <glib.h>     // for g_bytes_ref, g_bytes_hash, g_mutex_locker_new
+#include <stdbool.h>  // for bool, true, false
+#include <stddef.h>   // for NULL, size_t
+#include <stdint.h>   // for int64_t, SIZE_MAX, intmax_t
+#include "debug.h"    // for laik_tcp_debug
+#include "errors.h"   // for laik_tcp_always
+
+struct Laik_Tcp_Map {
+    GMutex* mutex;
+    GCond*  changed;
+
+    GHashTable* hash;
+
+    size_t size;
+    size_t limit;
+};
+
+static void laik_tcp_map_destroy (void* bytes) {
+    g_bytes_unref (bytes);
+}
+
+static size_t laik_tcp_map_minus (size_t x, size_t y) {
+    return x >= y ? x - y : 0;
+}
+
+static size_t laik_tcp_map_plus (size_t x, size_t y) {
+    return SIZE_MAX - x >= y ? x + y : SIZE_MAX;
+}
+
+void laik_tcp_map_add (Laik_Tcp_Map* this, GBytes* key, GBytes* value) {
+    laik_tcp_always (this);
+    laik_tcp_always (key);
+    laik_tcp_always (value);
+
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (this->mutex);
+
+    laik_tcp_debug ("Adding key 0x%08X", g_bytes_hash (key));
+
+    if (g_hash_table_contains (this->hash, key)) {
+        laik_tcp_debug ("Key already exists, aborting");
+        return;
+    }
+
+    this->size = laik_tcp_map_plus (this->size, g_bytes_get_size (value));
+
+    g_hash_table_insert (this->hash, g_bytes_ref (key), g_bytes_ref (value));
+
+    g_cond_broadcast (this->changed);
+}
+
+void laik_tcp_map_block (Laik_Tcp_Map* this) {
+    laik_tcp_always (this);
+
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (this->mutex);
+
+    laik_tcp_debug ("Waiting for mapping to be within its limits, currently %zu/%zu bytes occupied", this->size, this->limit);
+
+    while (this->size > this->limit) {
+        g_cond_wait (this->changed, this->mutex);
+    }
+
+    laik_tcp_debug ("Mapping is now within its limits, now %zu/%zu bytes occupied", this->size, this->limit);
+}
+
+void laik_tcp_map_discard (Laik_Tcp_Map* this, GBytes* key) {
+    laik_tcp_always (this);
+    laik_tcp_always (key);
+
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (this->mutex);
+
+    laik_tcp_debug ("Discarding key 0x%08X", g_bytes_hash (key));
+
+    if (this->size == SIZE_MAX) {
+        laik_tcp_debug ("Mapping may grow to infinite size, aborting");
+        return;
+    }
+
+    GBytes* value = g_hash_table_lookup (this->hash, key);
+
+    if (!value) {
+        laik_tcp_debug ("Key is missing or already discarded, aborting");
+        return;
+    }
+
+    this->size = laik_tcp_map_minus (this->size, g_bytes_get_size (value));
+
+    g_hash_table_insert (this->hash, g_bytes_ref (key), NULL);
+
+    g_cond_broadcast (this->changed);
+}
+
+void laik_tcp_map_free (Laik_Tcp_Map* this) {
+    if (!this) {
+        return;
+    }
+
+    // Free the lock
+    g_mutex_clear (this->mutex);
+    g_free (this->mutex);
+
+    // Free the condition variable
+    g_cond_clear (this->changed);
+    g_free (this->changed);
+
+    // Free the hash tables
+    g_hash_table_unref (this->hash);
+
+    // Free ourself
+    g_free (this);
+}
+
+GBytes* laik_tcp_map_get (Laik_Tcp_Map* this, const GBytes* key, const int64_t microseconds) {
+    laik_tcp_always (this);
+    laik_tcp_always (key);
+
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (this->mutex);
+
+    laik_tcp_debug ("Looking up key 0x%08X with a time limit of %jd microseconds", g_bytes_hash (key), (intmax_t) microseconds);
+
+    const int64_t timeout = g_get_monotonic_time () + microseconds;
+
+    GBytes* value = NULL;
+
+    while (!g_hash_table_lookup_extended (this->hash, key, NULL, (void**) &value)) {
+        if (!g_cond_wait_until (this->changed, this->mutex, timeout)) {
+            return NULL;
+        }
+    }
+
+    return value ? g_bytes_ref (value) : NULL;
+}
+
+Laik_Tcp_Map* laik_tcp_map_new (size_t limit) {
+    // Create a mutex which all object methods need to lock before beginning
+    g_autofree GMutex* mutex = g_new0 (GMutex, 1);
+    g_mutex_init (mutex);
+
+    // Create a condition variable which means "the mapping has changed somehow"
+    g_autofree GCond* changed = g_new0 (GCond, 1);
+    g_cond_init (changed);
+
+    Laik_Tcp_Map* this = g_new0 (Laik_Tcp_Map, 1);
+
+    *this = (Laik_Tcp_Map) {
+        .mutex   = g_steal_pointer (&mutex),
+        .changed = g_steal_pointer (&changed),
+
+        // Create the hash table for the mapping
+        .hash = g_hash_table_new_full (g_bytes_hash, g_bytes_equal, laik_tcp_map_destroy, laik_tcp_map_destroy),
+
+        // Set up the initial and maximum value for the total size of all mappings
+        .size  = 0,
+        .limit = limit,
+    };
+
+    return this;
+}
+
+bool laik_tcp_map_try (Laik_Tcp_Map* this, GBytes* key, GBytes* value) {
+    laik_tcp_always (this);
+    laik_tcp_always (key);
+    laik_tcp_always (value);
+
+    __attribute__ ((unused))
+    g_autoptr (GMutexLocker) locker = g_mutex_locker_new (this->mutex);
+
+    laik_tcp_debug ("Trying to add key 0x%08X", g_bytes_hash (key));
+
+    if (g_hash_table_contains (this->hash, key)) {
+        laik_tcp_debug ("Key already exists, aborting");
+        return true;
+    }
+
+    if (laik_tcp_map_plus (this->size, g_bytes_get_size (value)) > this->limit) {
+        laik_tcp_debug ("Value would exceed limit, aborting");
+        return false;
+    }
+
+    this->size = laik_tcp_map_plus (this->size, g_bytes_get_size (value));
+
+    g_hash_table_insert (this->hash, g_bytes_ref (key), g_bytes_ref (value));
+
+    g_cond_broadcast (this->changed);
+
+    return true;
+}

--- a/src/backends/tcp/map.h
+++ b/src/backends/tcp/map.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib.h>     // for GBytes, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stdbool.h>  // for bool
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for int64_t
+
+
+typedef struct Laik_Tcp_Map Laik_Tcp_Map;
+
+void laik_tcp_map_add (Laik_Tcp_Map* this, GBytes* key, GBytes* value);
+
+void laik_tcp_map_block (Laik_Tcp_Map* this);
+
+void laik_tcp_map_free ();
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Map, laik_tcp_map_free)
+
+void laik_tcp_map_discard (Laik_Tcp_Map* this, GBytes* key);
+
+__attribute__ ((warn_unused_result))
+GBytes* laik_tcp_map_get (Laik_Tcp_Map* this, const GBytes* key, int64_t microseconds);
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Map* laik_tcp_map_new (size_t limit);
+
+bool laik_tcp_map_try (Laik_Tcp_Map* this, GBytes* key, GBytes* value);

--- a/src/backends/tcp/messenger.c
+++ b/src/backends/tcp/messenger.c
@@ -1,0 +1,290 @@
+#include "messenger.h"
+#include <glib.h>     // for g_bytes_hash, g_autoptr, GBytes, g_async_queue_...
+#include <stdbool.h>  // for bool, true
+#include <stddef.h>   // for NULL, size_t
+#include <stdint.h>   // for int64_t, uint64_t, intmax_t
+#include "client.h"   // for laik_tcp_client_new, laik_tcp_client_connect
+#include "config.h"   // for laik_tcp_config, Laik_Tcp_Config, Laik_Tcp_Conf...
+#include "debug.h"    // for laik_tcp_debug, laik_tcp_always
+#include "errors.h"   // for laik_tcp_errors_new, Laik_Tcp_Errors_autoptr
+#include "map.h"      // for laik_tcp_map_new, laik_tcp_map_add, laik_tcp_ma...
+#include "server.h"   // for laik_tcp_server_new, laik_tcp_server_accept
+#include "socket.h"   // for laik_tcp_socket_send_bytes, laik_tcp_socket_sen...
+#include "task.h"     // for Laik_Tcp_Task, laik_tcp_task_new, laik_tcp_task..
+
+struct Laik_Tcp_Messenger {
+    Laik_Tcp_Client* client;
+    Laik_Tcp_Server* server;
+
+    Laik_Tcp_Map* inbox;
+    Laik_Tcp_Map* outbox;
+
+    GAsyncQueue* tasks;
+
+    GThread* client_thread;
+    GThread* server_thread;
+
+    int64_t client_microseconds;
+    int64_t server_microseconds;
+
+    bool client_stop;
+    bool server_stop;
+
+    size_t add_success;
+    size_t add_total;
+
+    size_t get_success;
+    size_t get_total;
+
+    size_t try_success;
+    size_t try_total;
+};
+
+typedef enum {
+    MESSAGE_ADD = 0,
+    MESSAGE_GET = 1,
+    MESSAGE_TRY = 2,
+} MessageType;
+
+#define CHECK(exp) { if (exp) { laik_tcp_debug ("[PASS] " #exp); } else { laik_tcp_debug ("[FAIL] " #exp); continue; } }
+
+static const char* laik_tcp_messenger_lookup (size_t id) {
+    g_autoptr (Laik_Tcp_Config) config =  laik_tcp_config ();
+
+    if (id < config->addresses->len) {
+        return g_ptr_array_index (config->addresses, id);
+    } else {
+        return NULL;
+    }
+}
+
+static void* laik_tcp_messenger_client_run (void* data) {
+    laik_tcp_always (data);
+
+    Laik_Tcp_Messenger* this = data;
+
+    while (!this->client_stop) {
+        g_autoptr (Laik_Tcp_Task)   task     = NULL;
+        g_autoptr (Laik_Tcp_Socket) socket   = NULL;
+        g_autoptr (GBytes)          body     = NULL;
+        uint64_t                    response = 0;
+        const char*                 address  = NULL;
+
+        CHECK ((task = g_async_queue_timeout_pop (this->tasks, this->client_microseconds)));
+
+        laik_tcp_debug ("Sending a message of type %d for header 0x%08X", task->type, g_bytes_hash (task->header));
+
+        CHECK ((address = laik_tcp_messenger_lookup (task->peer)));
+        CHECK ((socket = laik_tcp_client_connect (this->client, address)));
+        CHECK (laik_tcp_socket_send_uint64 (socket, task->type));
+        CHECK (laik_tcp_socket_send_bytes (socket, task->header));
+
+        switch (task->type) {
+            case MESSAGE_GET:
+                this->get_total++;
+
+                CHECK (laik_tcp_socket_receive_uint64 (socket, &response));
+
+                if (response) {
+                    CHECK ((body = laik_tcp_socket_receive_bytes (socket)));
+                    laik_tcp_map_add (this->inbox, task->header, body);
+                    this->get_success++;
+                }
+
+                break;
+
+            case MESSAGE_TRY:
+                this->try_total++;
+
+                CHECK ((body = laik_tcp_map_get (this->outbox, task->header, 0)));
+                CHECK (laik_tcp_socket_send_bytes (socket, body));
+                CHECK (laik_tcp_socket_receive_uint64 (socket, &response));
+
+                if (response) {
+                    laik_tcp_map_discard (this->outbox, task->header);
+                    this->try_success++;
+                }
+
+                break;
+
+            default:
+                continue;
+        }
+
+        laik_tcp_debug ("Message of type %d for header 0x%08X was %s", task->type, g_bytes_hash (task->header), response ? "accepted" : "refused");
+
+        // Hand the socket back so it can be re-used later on
+        laik_tcp_client_store (this->client, address, g_steal_pointer (&socket));
+    }
+
+    return NULL;
+}
+
+static void* laik_tcp_messenger_server_run (void* data) {
+    laik_tcp_always (data);
+
+    Laik_Tcp_Messenger* this = data;
+
+    while (!this->server_stop) {
+        uint64_t                    type   = 0;
+        g_autoptr (GBytes)          header = NULL;
+        g_autoptr (GBytes)          body   = NULL;
+        g_autoptr (Laik_Tcp_Socket) socket = NULL;
+
+        CHECK ((socket = laik_tcp_server_accept (this->server, this->server_microseconds)));
+        CHECK (laik_tcp_socket_receive_uint64 (socket, &type));
+        CHECK ((header = laik_tcp_socket_receive_bytes (socket)));
+
+        laik_tcp_debug ("Received a message of type %d for header 0x%08X", (int) type, g_bytes_hash (header));
+
+        switch (type) {
+            case MESSAGE_ADD:
+                CHECK ((body = laik_tcp_socket_receive_bytes (socket)));
+                laik_tcp_map_add (this->inbox, header, body);
+                break;
+
+            case MESSAGE_GET:
+                if ((body = laik_tcp_map_get (this->outbox, header, 0))) {
+                    CHECK (laik_tcp_socket_send_uint64 (socket, 1));
+                    CHECK (laik_tcp_socket_send_bytes (socket, body));
+                    laik_tcp_map_discard (this->outbox, header);
+                } else {
+                    CHECK (laik_tcp_socket_send_uint64 (socket, 0));
+                }
+                break;
+
+            case MESSAGE_TRY:
+                CHECK ((body = laik_tcp_socket_receive_bytes (socket)));
+                const bool response = laik_tcp_map_try (this->inbox, header, body);
+                CHECK (laik_tcp_socket_send_uint64 (socket, response));
+                break;
+
+            default:
+                continue;
+        }
+
+        // Hand the socket back so it can be re-used later on
+        laik_tcp_server_store (this->server, g_steal_pointer (&socket));
+    }
+
+    return NULL;
+}
+
+void laik_tcp_messenger_free (Laik_Tcp_Messenger* this) {
+    if (!this) {
+        return;
+    }
+
+    laik_tcp_debug ("Terminating messenger, ADD=%zu/%zu, GET=%zu/%zu, TRY=%zu/%zu"
+                   , this->add_success, this->add_total
+                   , this->get_success, this->get_total
+                   , this->try_success, this->try_total
+                   );
+
+    this->client_stop = true;
+    this->server_stop = true;
+
+    (void) g_thread_join (this->client_thread);
+    (void) g_thread_join (this->server_thread);
+
+    laik_tcp_client_free (this->client);
+    laik_tcp_server_free (this->server);
+
+    laik_tcp_map_free (this->inbox);
+    laik_tcp_map_free (this->outbox);
+
+    g_async_queue_unref (this->tasks);
+
+    g_free (this);
+}
+
+GBytes* laik_tcp_messenger_get (Laik_Tcp_Messenger* this, size_t sender, GBytes* header) {
+    laik_tcp_always (this);
+    laik_tcp_always (header);
+
+    GBytes* body         = NULL;
+    int64_t microseconds = G_TIME_SPAN_MILLISECOND;
+
+    laik_tcp_debug ("Getting message 0x%08X from peer %zu", g_bytes_hash (header), sender);
+
+    while (!(body = laik_tcp_map_get (this->inbox, header, microseconds))) {
+        laik_tcp_debug ("Waiting for message 0x%08X from peer %zu for %jd microseconds timed out, queuing request"
+              , g_bytes_hash (header)
+              , sender
+              , (intmax_t) microseconds
+              );
+
+        g_async_queue_push (this->tasks, laik_tcp_task_new (MESSAGE_GET, sender, header));
+
+        microseconds = MIN (G_TIME_SPAN_SECOND, microseconds * 2);
+    }
+
+    laik_tcp_map_discard (this->inbox, header);
+
+    return body;
+}
+
+Laik_Tcp_Messenger* laik_tcp_messenger_new (Laik_Tcp_Socket* socket) {
+    laik_tcp_always (socket);
+
+    Laik_Tcp_Messenger* this = g_new0 (Laik_Tcp_Messenger, 1);
+
+    *this = (Laik_Tcp_Messenger) {
+        .client = laik_tcp_client_new (3),
+        .server = laik_tcp_server_new (socket, 4),
+
+        .inbox   = laik_tcp_map_new (1<<24),
+        .outbox  = laik_tcp_map_new (1<<24),
+
+        .tasks = g_async_queue_new_full (laik_tcp_task_destroy),
+
+        .client_microseconds = 10 * G_TIME_SPAN_MILLISECOND,
+        .server_microseconds = 10 * G_TIME_SPAN_MILLISECOND,
+    };
+
+    this->client_thread = g_thread_new ("Client Thread", laik_tcp_messenger_client_run, this);
+    this->server_thread = g_thread_new ("Server Thread", laik_tcp_messenger_server_run, this);
+
+    return this;
+}
+
+void laik_tcp_messenger_push (Laik_Tcp_Messenger* this, size_t receiver, GBytes* header, GBytes* body) {
+    laik_tcp_always (this);
+    laik_tcp_always (header);
+    laik_tcp_always (body);
+
+    laik_tcp_debug ("Pushing message 0x%08X to peer %zu", g_bytes_hash (header), receiver);
+
+    laik_tcp_map_add (this->outbox, header, body);
+
+    g_async_queue_push (this->tasks, laik_tcp_task_new (MESSAGE_TRY, receiver, header));
+
+    laik_tcp_map_block (this->outbox);
+}
+
+void laik_tcp_messenger_send (Laik_Tcp_Messenger* this, size_t receiver, GBytes* header, GBytes* body) {
+    laik_tcp_always (this);
+    laik_tcp_always (header);
+    laik_tcp_always (body);
+
+    const char*      address = NULL;
+    Laik_Tcp_Socket* socket  = NULL;
+
+    laik_tcp_debug ("Sending message 0x%08X to peer %zu", g_bytes_hash (header), receiver);
+
+    while (true) {
+        g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+        this->add_total++;
+
+        CHECK ((address = laik_tcp_messenger_lookup (receiver)));
+        CHECK ((socket = laik_tcp_socket_new (LAIK_TCP_SOCKET_TYPE_CLIENT, address, errors)));
+        CHECK (laik_tcp_socket_send_uint64 (socket, MESSAGE_ADD));
+        CHECK (laik_tcp_socket_send_bytes (socket, header));
+        CHECK (laik_tcp_socket_send_bytes (socket, body));
+
+        this->add_success++;
+
+        break;
+    }
+}

--- a/src/backends/tcp/messenger.h
+++ b/src/backends/tcp/messenger.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <glib.h>    // for GBytes, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stddef.h>  // for size_t
+#include "socket.h"  // for Laik_Tcp_Socket
+
+typedef struct Laik_Tcp_Messenger Laik_Tcp_Messenger;
+
+void laik_tcp_messenger_free (Laik_Tcp_Messenger* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Messenger, laik_tcp_messenger_free)
+
+__attribute__ ((warn_unused_result))
+GBytes* laik_tcp_messenger_get (Laik_Tcp_Messenger* this, size_t sender, GBytes* header);
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Messenger* laik_tcp_messenger_new (Laik_Tcp_Socket* socket);
+
+void laik_tcp_messenger_push (Laik_Tcp_Messenger* this, size_t receiver, GBytes* header, GBytes* body);
+
+void laik_tcp_messenger_send (Laik_Tcp_Messenger* this, size_t receiver, GBytes* header, GBytes* body);

--- a/src/backends/tcp/minimpi.c
+++ b/src/backends/tcp/minimpi.c
@@ -1,0 +1,609 @@
+#include "minimpi.h"
+#include <endian.h>     // for htole64, htobe64
+#include <glib.h>       // for g_autoptr, g_bytes_get_size, GBytes_autoptr
+#include <stdbool.h>    // for false
+#include <stdint.h>     // for uint64_t, int64_t, SIZE_MAX
+#include <stdio.h>      // for snprintf
+#include <stdlib.h>     // for getenv, strtoull
+#include <string.h>     // for memcpy
+#include <unistd.h>     // for getpid
+#include "config.h"     // for laik_tcp_config, Laik_Tcp_Config, Laik_Tcp_Co...
+#include "debug.h"      // for laik_tcp_always, laik_tcp_debug
+#include "errors.h"     // for laik_tcp_errors_push, laik_tcp_errors_present
+#include "messenger.h"  // for laik_tcp_messenger_get, laik_tcp_messenger_push
+#include "socket.h"     // for laik_tcp_socket_new_server, Laik_Tcp_Socket_a...
+
+// Type definitions
+
+struct Laik_Tcp_MiniMpiComm {
+    GArray*  tasks;      // Mapping from per-communicator ranks to world ranks
+    size_t   rank;       // Our own rank in this communicator
+    size_t   generation; // The number of generations to the world communicator
+};
+
+typedef struct __attribute__ ((packed)) {
+    int64_t  color;
+    int64_t  hint;
+    uint64_t rank;
+} Laik_Tcp_Split;
+
+typedef enum {
+    TYPE_BARRIER      = 0xaa,
+    TYPE_BROADCAST    = 0xbb,
+    TYPE_REDUCE       = 0xcc,
+    TYPE_SEND_RECEIVE = 0xdd,
+    TYPE_SPLIT        = 0xee,
+} MessageType;
+
+// Internal variables
+
+static GHashTable*         flows     = NULL;
+static Laik_Tcp_Messenger* messenger = NULL;
+
+// Internal functions
+
+static void laik_tcp_minimpi_destroy (void* data) {
+    g_bytes_unref (data);
+}
+
+__attribute__ ((warn_unused_result))
+static Laik_Tcp_MiniMpiComm* laik_tcp_minimpi_new (GArray* tasks, size_t rank, size_t generation) {
+    Laik_Tcp_MiniMpiComm* this = g_new0 (Laik_Tcp_MiniMpiComm, 1);
+
+    *this = (Laik_Tcp_MiniMpiComm) {
+        .tasks      = tasks,
+        .rank       = rank,
+        .generation = generation,
+    };
+
+    return this;
+}
+
+__attribute__ ((warn_unused_result))
+static size_t laik_tcp_minimpi_lookup (const Laik_Tcp_MiniMpiComm* comm, size_t rank) {
+    laik_tcp_always (comm);
+    laik_tcp_always (comm->tasks);
+    laik_tcp_always (rank < comm->tasks->len);
+
+    return g_array_index (comm->tasks, size_t, rank);
+}
+
+__attribute__ ((warn_unused_result))
+static GBytes* laik_tcp_minimpi_header (uint64_t generation, uint64_t type, uint64_t sender, uint64_t receiver, uint64_t tag) {
+    laik_tcp_always (flows);
+
+    const uint64_t data[] = {
+        htole64 (generation),
+        htole64 (type),
+        htole64 (sender),
+        htole64 (receiver),
+        htole64 (tag),
+        htole64 (0),
+    };
+
+    GBytes* result = g_bytes_new (&data, sizeof (data));
+
+    uint64_t* serial = g_hash_table_lookup (flows, result);
+
+    if (serial) {
+        ((uint64_t*) g_bytes_get_data (result, NULL))[5] = htobe64 (++*serial);
+    } else {
+        g_hash_table_insert (flows, g_bytes_ref (result), g_new0 (uint64_t, 1));
+    }
+
+    return result;
+}
+
+__attribute__ ((warn_unused_result))
+static int laik_tcp_minimpi_error (Laik_Tcp_Errors* errors) {
+    laik_tcp_always (errors);
+
+    if (laik_tcp_errors_present (errors)) {
+        return g_quark_from_string (laik_tcp_errors_show (errors));
+    } else {
+        return LAIK_TCP_MINIMPI_SUCCESS;
+    }
+}
+
+__attribute__ ((warn_unused_result))
+static int laik_tcp_split_compare (const void* a, const void* b) {
+    const Laik_Tcp_Split* x = a;
+    const Laik_Tcp_Split* y = b;
+
+    return x->hint - y->hint;
+}
+
+static size_t laik_tcp_minimpi_sizeof (const Laik_Tcp_MiniMpiType datatype, Laik_Tcp_Errors* errors) {
+    laik_tcp_always (errors);
+
+    switch (datatype) {
+        case LAIK_TCP_MINIMPI_DOUBLE:
+            return sizeof (double);
+        case LAIK_TCP_MINIMPI_FLOAT:
+            return sizeof (float);
+        default:
+            laik_tcp_errors_push (errors, __func__, 0, "Invalid MPI datatype %d", datatype);
+            return 0;
+    }
+}
+
+static void laik_tcp_minimpi_combine (void* buffer, const void* data, const size_t elements, const Laik_Tcp_MiniMpiType datatype, const Laik_Tcp_MiniMpiOp op, Laik_Tcp_Errors* errors) {
+    laik_tcp_always (buffer);
+    laik_tcp_always (data);
+    laik_tcp_always (errors);
+
+    switch (op) {
+        case LAIK_TCP_MINIMPI_SUM:
+            switch (datatype) {
+                case LAIK_TCP_MINIMPI_DOUBLE:
+                    {
+                        double* b = buffer;
+                        const double* d = data;
+                        for (size_t i = 0; i < elements; i++) {
+                            b[i] += d[i];
+                        }
+                    }
+                    break;
+                case LAIK_TCP_MINIMPI_FLOAT:
+                    {
+                        float* b = buffer;
+                        const float* d = data;
+                        for (size_t i = 0; i < elements; i++) {
+                            b[i] += d[i];
+                        }
+                    }
+                    break;
+                default:
+                    laik_tcp_errors_push (errors, __func__, 0, "Invalid MPI datatype %d", datatype);
+                    break;
+            }
+            break;
+        default:
+            laik_tcp_errors_push (errors, __func__, 1, "Invalid MPI operation %d", op);
+            break;
+    }
+}
+
+// Public variables
+
+Laik_Tcp_MiniMpiComm* LAIK_TCP_MINIMPI_COMM_WORLD = NULL;
+
+// Public functions
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Allreduce.html
+int laik_tcp_minimpi_allreduce (const void* input_buffer, void* output_buffer, const int elements, const Laik_Tcp_MiniMpiType datatype, const Laik_Tcp_MiniMpiOp op, const Laik_Tcp_MiniMpiComm* comm) {
+    laik_tcp_always (comm);
+
+    const size_t root = 0;
+
+    const int reduce_result = laik_tcp_minimpi_reduce (input_buffer, output_buffer, elements, datatype, op, root, comm);
+    if (reduce_result != LAIK_TCP_MINIMPI_SUCCESS) {
+        return reduce_result;
+    }
+
+    const int bcast_result = laik_tcp_minimpi_bcast (output_buffer, elements, datatype, root, comm);
+    if (bcast_result != LAIK_TCP_MINIMPI_SUCCESS) {
+        return bcast_result;
+    }
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/latest/www/www3/MPI_Barrier.html
+int laik_tcp_minimpi_barrier (const Laik_Tcp_MiniMpiComm* comm) {
+    laik_tcp_always (comm);
+
+    laik_tcp_debug ("MPI_Barrier entered by task %zu", comm->rank);
+
+    const int master = 0;
+
+    if (comm->rank == master) {
+        // Receive the ping message from all slaves
+        for (size_t slave = 1; slave < comm->tasks->len; slave++) {
+            g_autoptr (GBytes) ping_header = laik_tcp_minimpi_header (comm->generation, TYPE_BARRIER, slave, master, 0);
+            g_autoptr (GBytes) ping_body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, slave), ping_header);
+            (void) ping_body;
+            laik_tcp_debug ("Master got ping from slave %zu", slave);
+        }
+
+        // Synchronously (!) send the pong to all slaves
+        for (size_t slave = 1; slave < comm->tasks->len; slave++) {
+            g_autoptr (GBytes) pong_header = laik_tcp_minimpi_header (comm->generation, TYPE_BARRIER, master, slave, 0);
+            g_autoptr (GBytes) pong_body   = g_bytes_new (NULL, 0);
+            laik_tcp_messenger_send (messenger, laik_tcp_minimpi_lookup (comm, slave), pong_header, pong_body);
+            laik_tcp_debug ("Master sent pong to slave %zu", slave);
+        }
+    } else {
+        // Send the ping message to the master
+        g_autoptr (GBytes) ping_header = laik_tcp_minimpi_header (comm->generation, TYPE_BARRIER, comm->rank, master, 0);
+        g_autoptr (GBytes) ping_body   = g_bytes_new (NULL, 0);
+        laik_tcp_messenger_push (messenger, laik_tcp_minimpi_lookup (comm, master), ping_header, ping_body);
+        laik_tcp_debug ("Slave %zu sent ping to master", comm->rank);
+
+        // Receive the pong message from the master
+        g_autoptr (GBytes) pong_header = laik_tcp_minimpi_header (comm->generation, TYPE_BARRIER, master, comm->rank, 0);
+        g_autoptr (GBytes) pong_body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, master), pong_header);
+        (void) pong_body;
+        laik_tcp_debug ("Slave %zu got pong from master", comm->rank);
+    }
+
+    laik_tcp_debug ("MPI_Barrier completed by task %zu", comm->rank);
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/latest/www/www3/MPI_Bcast.html
+int laik_tcp_minimpi_bcast (void* buffer, const int elements, const Laik_Tcp_MiniMpiType datatype, const size_t root, const Laik_Tcp_MiniMpiComm* comm) {
+    laik_tcp_always (comm);
+    laik_tcp_always (root < comm->tasks->len);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const size_t size = elements * laik_tcp_minimpi_sizeof (datatype, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine size of data type");
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    if (comm->rank == root) {
+        g_autoptr (GBytes) body = g_bytes_new (buffer, size);
+
+        for (size_t receiver = 0; receiver < comm->tasks->len; receiver++) {
+            if (receiver != comm->rank) {
+                g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_BROADCAST, root, receiver, 0);
+
+                laik_tcp_messenger_push (messenger, laik_tcp_minimpi_lookup (comm, receiver), header, body);
+            }
+        }
+    } else {
+        g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_BROADCAST, root, comm->rank, 0);
+        g_autoptr (GBytes) body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, root), header);
+
+        if (g_bytes_get_size (body) != size) {
+            laik_tcp_errors_push (errors, __func__, 1, "Broadcast from root task %zu was %zu bytes, expected %zu bytes", root, g_bytes_get_size (body), size);
+            return laik_tcp_minimpi_error (errors);
+        }
+
+        memcpy (buffer, g_bytes_get_data (body, NULL), size);
+    }
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Comm_dup.html
+int laik_tcp_minimpi_comm_dup (const Laik_Tcp_MiniMpiComm* comm, Laik_Tcp_MiniMpiComm** new_communicator) {
+    laik_tcp_always (comm);
+
+    *new_communicator = laik_tcp_minimpi_new (g_array_ref (comm->tasks), comm->rank, comm->generation + 1);
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Comm_rank.html
+int laik_tcp_minimpi_comm_rank (const Laik_Tcp_MiniMpiComm* comm, int* rank) {
+    laik_tcp_always (comm);
+
+    *rank = comm->rank;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Comm_size.html
+int laik_tcp_minimpi_comm_size (const Laik_Tcp_MiniMpiComm* comm, int* size) {
+    laik_tcp_always (comm);
+
+    *size = comm->tasks->len;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Comm_split.html
+int laik_tcp_minimpi_comm_split (const Laik_Tcp_MiniMpiComm* comm, const int color, const int hint, Laik_Tcp_MiniMpiComm** new_communicator) {
+    laik_tcp_always (comm);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    // Create our own split info structure
+    const Laik_Tcp_Split split = {
+        .color = color,
+        .hint  = hint,
+        .rank  = comm->rank,
+    };
+
+    // Create a serialized version of our split info structure
+    g_autoptr (GBytes) split_bytes = g_bytes_new (&split, sizeof (split));
+
+    // Create an array to hold all the split info structures
+    g_autoptr (GArray) splits = g_array_new (false, false, sizeof (Laik_Tcp_Split));
+
+    // Insert ourselves into the array
+    g_array_append_vals (splits, &split, 1);
+
+    // Iterate over all peers
+    for (size_t sender = 0; sender < comm->tasks->len; sender++) {
+        if (sender == comm->rank) {
+            // It's our turn to send our split info structure all other peers
+            for (size_t receiver = 0; receiver < comm->tasks->len; receiver++) {
+                if (receiver != comm->rank) {
+                    g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_SPLIT, sender, receiver, 0);
+                    laik_tcp_messenger_push (messenger, laik_tcp_minimpi_lookup (comm, receiver), header, split_bytes);
+                }
+            }
+        } else {
+            // It's not our turn to send, instead we should receive data
+            g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_SPLIT, sender, comm->rank, 0);
+            g_autoptr (GBytes) body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, sender), header);
+
+            if (g_bytes_get_size (body) != sizeof (Laik_Tcp_Split)) {
+                laik_tcp_errors_push (errors, __func__, 0, "Task %zu sent %zu bytes when splitting, expected %zu bytes", sender, g_bytes_get_size (body), sizeof (Laik_Tcp_Split));
+                return laik_tcp_minimpi_error (errors);
+            }
+
+            g_array_append_vals (splits, g_bytes_get_data (body, NULL), 1);
+        }
+    }
+
+    // Create a new task list
+    g_autoptr (GArray) tasks = g_array_new (false, false, sizeof (size_t));
+
+    // Sort all the split info structures (including our own!) by hint
+    g_array_sort (splits, laik_tcp_split_compare);
+
+    // Initialize our new rank with something invalid
+    size_t new_local_rank = SIZE_MAX;
+
+    // Iterate over all the split info structures
+    for (size_t i = 0; i < splits->len; i++) {
+        const Laik_Tcp_Split split = g_array_index (splits, Laik_Tcp_Split, i);
+
+        // If we have reached our own split info, we have found our new rank
+        if (split.rank == comm->rank) {
+            new_local_rank = tasks->len;
+        }
+
+        // If it's us or somebody with the same color, add them to the task list
+        if (split.rank == comm->rank || (split.color == color && split.color != LAIK_TCP_MINIMPI_UNDEFINED)) {
+            const size_t world_rank = laik_tcp_minimpi_lookup (comm, split.rank);
+            g_array_append_vals (tasks, &world_rank, 1);
+        }
+    }
+
+    // Make sure we have set our new local rank to something valid
+    laik_tcp_always (new_local_rank < tasks->len);
+
+    // Construct the new communicator
+    *new_communicator = laik_tcp_minimpi_new (g_steal_pointer (&tasks), new_local_rank, comm->generation + 1);
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Error_string.html
+int laik_tcp_minimpi_error_string (int error_code, char *string, int *result_length) {
+    laik_tcp_always (string);
+    laik_tcp_always (result_length);
+
+    size_t bytes = snprintf (string, LAIK_TCP_MINIMPI_MAX_ERROR_STRING, "%s", g_quark_to_string (error_code));
+    laik_tcp_always (bytes < LAIK_TCP_MINIMPI_MAX_ERROR_STRING);
+    *result_length = bytes;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Finalize.html
+int laik_tcp_minimpi_finalize (void) {
+    laik_tcp_always (flows);
+    laik_tcp_always (messenger);
+
+    // Enforce global synchronization before going down
+    (void) laik_tcp_minimpi_barrier (LAIK_TCP_MINIMPI_COMM_WORLD);
+
+    LAIK_TCP_MINIMPI_COMM_WORLD = NULL;
+
+    g_hash_table_unref (flows);
+    flows = NULL;
+
+    laik_tcp_messenger_free (messenger);
+    messenger = NULL;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Get_count.html
+int laik_tcp_minimpi_get_count (const Laik_Tcp_MiniMpiStatus* status, const Laik_Tcp_MiniMpiType datatype, int* count){
+    laik_tcp_always (status);
+    laik_tcp_always (count);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const size_t size = laik_tcp_minimpi_sizeof (datatype, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine size of data type");
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    *count = *status / size;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Get_processor_name.html
+int laik_tcp_minimpi_get_processor_name (char* name, int* result_length) {
+    laik_tcp_always (name);
+    laik_tcp_always (result_length);
+
+    size_t bytes = snprintf (name, LAIK_TCP_MINIMPI_MAX_PROCESSOR_NAME, "%d", getpid ());
+    laik_tcp_always (bytes < LAIK_TCP_MINIMPI_MAX_PROCESSOR_NAME);
+    *result_length = bytes;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Initialized.html
+int laik_tcp_minimpi_initialized (int* flag) {
+    *flag = LAIK_TCP_MINIMPI_COMM_WORLD != NULL;
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Init.html
+int laik_tcp_minimpi_init (int* argc, char*** argv) {
+    (void) argc;
+    (void) argv;
+
+    // Construct a temporary error stack
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    // Get the configuration object
+    g_autoptr (Laik_Tcp_Config) config = laik_tcp_config ();
+
+    // Initialize the rank variable
+    size_t rank = 0;
+
+    // Initialize the socket variable
+    g_autoptr (Laik_Tcp_Socket) socket = NULL;
+
+    // Iterate over all ranks and see if we can create a socket for one
+    for (rank = 0; rank < config->addresses->len; rank++) {
+        // Retrieve the address assigned to the current rank
+        const char* address = g_ptr_array_index (config->addresses, rank);
+
+        // Try to create the server socket for this address
+        socket = laik_tcp_socket_new (LAIK_TCP_SOCKET_TYPE_SERVER, address, errors);
+
+        // Check if there was an error
+        if (laik_tcp_errors_present (errors)) {
+            laik_tcp_debug ("Failed to bind socket to address %s", address);
+
+            // There was an error, check if there are other addresses to try
+            if (rank + 1 < config->addresses->len) {
+                // There are still addresses left to try, continue
+                laik_tcp_errors_clear (errors);
+            } else {
+                // There are no more addresses left to try, abort
+                laik_tcp_errors_push (errors, __func__, 1, "Could not bind any task address");
+                return laik_tcp_minimpi_error (errors);
+
+            }
+        } else {
+            laik_tcp_debug ("Successfully bound socket to address %s", address);
+
+            // There was no error, break from the loop since we found our socket
+            break;
+        }
+    }
+
+    // Create the flow database shared by all communicators
+    flows = g_hash_table_new_full (g_bytes_hash, g_bytes_equal, laik_tcp_minimpi_destroy, g_free);
+
+    // Create the messenger shared by all communicators
+    messenger = laik_tcp_messenger_new (g_steal_pointer (&socket));
+
+    // Create the "world" communicator
+    g_autoptr (GArray) tasks = g_array_sized_new (false, false, sizeof (size_t), config->addresses->len);
+    for (size_t i = 0; i < config->addresses->len; i++) {
+        g_array_append_vals (tasks, &i, 1);
+    }
+    LAIK_TCP_MINIMPI_COMM_WORLD = laik_tcp_minimpi_new (g_steal_pointer (&tasks), rank, 0);
+
+    // Return success
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Recv.html
+int laik_tcp_minimpi_recv (void* buffer, const int elements, Laik_Tcp_MiniMpiType datatype, const size_t sender, const int tag, const Laik_Tcp_MiniMpiComm* comm, Laik_Tcp_MiniMpiStatus* status) {
+    laik_tcp_always (comm);
+    laik_tcp_always (sender < comm->tasks->len);
+    laik_tcp_always (sender != comm->rank);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const size_t size = elements * laik_tcp_minimpi_sizeof (datatype, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine size of data type");
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_SEND_RECEIVE, sender, comm->rank, tag);
+    g_autoptr (GBytes) body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, sender), header);
+
+    if (g_bytes_get_size (body) > size) {
+        laik_tcp_errors_push (errors, __func__, 1, "Message contains %zu bytes, but supplied buffer holds only %zu bytes", g_bytes_get_size (body), size);
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    memcpy (buffer, g_bytes_get_data (body, NULL), g_bytes_get_size (body));
+    *status = g_bytes_get_size (body);
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Reduce.html
+int laik_tcp_minimpi_reduce (const void* input_buffer, void* output_buffer, const int elements, const Laik_Tcp_MiniMpiType datatype, const Laik_Tcp_MiniMpiOp op, const size_t root, const Laik_Tcp_MiniMpiComm* comm) {
+    laik_tcp_always (comm);
+    laik_tcp_always (root < comm->tasks->len);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const size_t size = elements * laik_tcp_minimpi_sizeof (datatype, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine size of data type");
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    if (root == comm->rank) {
+        // Copy the input buffer to the output buffer if necessary
+        if (input_buffer != LAIK_TCP_MINIMPI_IN_PLACE) {
+            memcpy (output_buffer, input_buffer, size);
+        }
+
+         // Collect the result from all other peers and laik_tcp_minimpi_combine
+        for (size_t sender = 0; sender < comm->tasks->len; sender++) {
+            if (sender != comm->rank) {
+                g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_REDUCE, sender, root, 0);
+                g_autoptr (GBytes) body   = laik_tcp_messenger_get (messenger, laik_tcp_minimpi_lookup (comm, sender), header);
+
+                if (g_bytes_get_size (body) != size) {
+                    laik_tcp_errors_push (errors, __func__, 1, "Task %zu sent %zu bytes when reducing %zu bytes", sender, g_bytes_get_size (body), size);
+                    return laik_tcp_minimpi_error (errors);
+                }
+
+                laik_tcp_minimpi_combine (output_buffer, g_bytes_get_data (body, NULL), elements, datatype, op, errors);
+                if (laik_tcp_errors_present (errors)) {
+                    laik_tcp_errors_push (errors, __func__, 2, "Failed to reduce buffers");
+                    return laik_tcp_minimpi_error (errors);
+                }
+            }
+        }
+    } else {
+        const void* input = input_buffer == LAIK_TCP_MINIMPI_IN_PLACE ? output_buffer : input_buffer;
+
+        g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_REDUCE, comm->rank, root, 0);
+        g_autoptr (GBytes) body   = g_bytes_new (input, size);
+
+        laik_tcp_messenger_push (messenger, laik_tcp_minimpi_lookup (comm, root), header, body);
+    }
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}
+
+// https://www.mpich.org/static/docs/v3.2/www3/MPI_Send.html
+int laik_tcp_minimpi_send (const void* buffer, const int elements, const Laik_Tcp_MiniMpiType datatype, const size_t receiver, const int tag, const Laik_Tcp_MiniMpiComm* comm) {
+    laik_tcp_always (comm);
+    laik_tcp_always (receiver < comm->tasks->len);
+    laik_tcp_always (receiver != comm->rank);
+
+    g_autoptr (Laik_Tcp_Errors) errors = laik_tcp_errors_new ();
+
+    const size_t size = elements * laik_tcp_minimpi_sizeof (datatype, errors);
+    if (laik_tcp_errors_present (errors)) {
+        laik_tcp_errors_push (errors, __func__, 0, "Failed to determine size of data type");
+        return laik_tcp_minimpi_error (errors);
+    }
+
+    g_autoptr (GBytes) header = laik_tcp_minimpi_header (comm->generation, TYPE_SEND_RECEIVE, comm->rank, receiver, tag);
+    g_autoptr (GBytes) body   = g_bytes_new (buffer, size);
+
+    laik_tcp_messenger_push (messenger, laik_tcp_minimpi_lookup (comm, receiver), header, body);
+
+    return LAIK_TCP_MINIMPI_SUCCESS;
+}

--- a/src/backends/tcp/minimpi.h
+++ b/src/backends/tcp/minimpi.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <stddef.h>  // for size_t, NULL
+
+typedef enum {
+    LAIK_TCP_MINIMPI_DOUBLE,
+    LAIK_TCP_MINIMPI_FLOAT,
+} Laik_Tcp_MiniMpiType;
+
+typedef enum {
+    LAIK_TCP_MINIMPI_SUM
+} Laik_Tcp_MiniMpiOp;
+
+typedef size_t Laik_Tcp_MiniMpiStatus;
+
+typedef struct Laik_Tcp_MiniMpiComm Laik_Tcp_MiniMpiComm;
+
+extern Laik_Tcp_MiniMpiComm* LAIK_TCP_MINIMPI_COMM_WORLD;
+
+#define LAIK_TCP_MINIMPI_IN_PLACE           (NULL)
+#define LAIK_TCP_MINIMPI_MAX_ERROR_STRING   (1<<16)
+#define LAIK_TCP_MINIMPI_MAX_PROCESSOR_NAME (1<<16)
+#define LAIK_TCP_MINIMPI_SUCCESS            (0)
+#define LAIK_TCP_MINIMPI_UNDEFINED          (-1)
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_allreduce (const void* input_buffer, void* output_buffer, int elements, Laik_Tcp_MiniMpiType datatype, Laik_Tcp_MiniMpiOp op, const Laik_Tcp_MiniMpiComm* comm);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_barrier (const Laik_Tcp_MiniMpiComm* comm);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_bcast (void* buffer, int elements, Laik_Tcp_MiniMpiType datatype, size_t root, const Laik_Tcp_MiniMpiComm* comm);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_comm_dup (const Laik_Tcp_MiniMpiComm* comm, Laik_Tcp_MiniMpiComm** new_communicator);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_comm_rank (const Laik_Tcp_MiniMpiComm* comm, int* rank);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_comm_size (const Laik_Tcp_MiniMpiComm* comm, int* size);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_comm_split (const Laik_Tcp_MiniMpiComm* comm, int color, int hint, Laik_Tcp_MiniMpiComm** new_communicator);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_error_string (int error_code, char *string, int *result_length);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_finalize (void);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_get_count (const Laik_Tcp_MiniMpiStatus* status, Laik_Tcp_MiniMpiType datatype, int* elements);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_get_processor_name (char* name, int* result_length);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_initialized (int* flag);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_init (int* argc, char*** argv);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_recv (void* buffer, int elements, Laik_Tcp_MiniMpiType datatype, size_t sender, int tag, const Laik_Tcp_MiniMpiComm* comm, Laik_Tcp_MiniMpiStatus* status);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_reduce (const void* input_buffer, void* output_buffer, int elements, Laik_Tcp_MiniMpiType datatype, Laik_Tcp_MiniMpiOp op, size_t root, const Laik_Tcp_MiniMpiComm* comm);
+
+__attribute__ ((warn_unused_result))
+int laik_tcp_minimpi_send (const void* buffer, int elements, Laik_Tcp_MiniMpiType datatype, size_t receiver, int tag, const Laik_Tcp_MiniMpiComm* comm);

--- a/src/backends/tcp/mpi.h
+++ b/src/backends/tcp/mpi.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "minimpi.h"  // for LAIK_TCP_MINIMPI_COMM_WORLD, LAIK_TCP_MINIMPI_IN_PLACE, LAIK_TCP_MINIMPI_M...
+
+#define MPI_DOUBLE             LAIK_TCP_MINIMPI_DOUBLE
+#define MPI_FLOAT              LAIK_TCP_MINIMPI_FLOAT
+typedef Laik_Tcp_MiniMpiType MPI_Datatype;
+
+#define MPI_SUM                LAIK_TCP_MINIMPI_SUM
+typedef Laik_Tcp_MiniMpiOp MPI_Op;
+
+typedef struct Laik_Tcp_MiniMpiComm* MPI_Comm;
+
+#define MPI_Status             Laik_Tcp_MiniMpiStatus
+
+#define MPI_COMM_WORLD         LAIK_TCP_MINIMPI_COMM_WORLD
+#define MPI_IN_PLACE           LAIK_TCP_MINIMPI_IN_PLACE
+#define MPI_MAX_ERROR_STRING   LAIK_TCP_MINIMPI_MAX_ERROR_STRING
+#define MPI_MAX_PROCESSOR_NAME LAIK_TCP_MINIMPI_MAX_PROCESSOR_NAME
+#define MPI_SUCCESS            LAIK_TCP_MINIMPI_SUCCESS
+#define MPI_UNDEFINED          LAIK_TCP_MINIMPI_UNDEFINED
+
+#define MPI_Allreduce          laik_tcp_minimpi_allreduce
+#define MPI_Barrier            laik_tcp_minimpi_barrier
+#define MPI_Bcast              laik_tcp_minimpi_bcast
+#define MPI_Comm_dup           laik_tcp_minimpi_comm_dup
+#define MPI_Comm_rank          laik_tcp_minimpi_comm_rank
+#define MPI_Comm_size          laik_tcp_minimpi_comm_size
+#define MPI_Comm_split         laik_tcp_minimpi_comm_split
+#define MPI_Error_string       laik_tcp_minimpi_error_string
+#define MPI_Finalize           laik_tcp_minimpi_finalize
+#define MPI_Get_count          laik_tcp_minimpi_get_count
+#define MPI_Get_processor_name laik_tcp_minimpi_get_processor_name
+#define MPI_Initialized        laik_tcp_minimpi_initialized
+#define MPI_Init               laik_tcp_minimpi_init
+#define MPI_Recv               laik_tcp_minimpi_recv
+#define MPI_Reduce             laik_tcp_minimpi_reduce
+#define MPI_Send               laik_tcp_minimpi_send

--- a/src/backends/tcp/server.c
+++ b/src/backends/tcp/server.c
@@ -1,0 +1,88 @@
+#include "server.h"
+#include <glib.h>    // for g_ptr_array_add, GPtrArray, g_free, g_get_monoto...
+#include <poll.h>    // for POLLIN
+#include <stddef.h>  // for size_t, NULL
+#include "debug.h"   // for laik_tcp_debug
+#include "errors.h"  // for laik_tcp_always, laik_tcp_errors_present, laik_t...
+#include "socket.h"  // for laik_tcp_socket_free, laik_tcp_socket_get_listening
+
+struct Laik_Tcp_Server {
+    GPtrArray* connections;
+    size_t     limit;
+};
+
+Laik_Tcp_Socket* laik_tcp_server_accept (Laik_Tcp_Server* this, int64_t microseconds) {
+    laik_tcp_always (this);
+
+    Laik_Tcp_Socket* socket = laik_tcp_socket_poll (this->connections, POLLIN, microseconds);
+
+    if (!socket) {
+        return NULL;
+    }
+
+    if (laik_tcp_socket_get_listening (socket)) {
+        laik_tcp_debug ("Server socket found to be ready, accepting");
+        return laik_tcp_socket_accept (socket);
+    } else {
+        laik_tcp_debug ("Connection socket found to be ready, returning");
+        g_ptr_array_remove (this->connections, socket);
+        return socket;
+    }
+}
+
+void laik_tcp_server_free (Laik_Tcp_Server* this) {
+    if (!this) {
+        return;
+    }
+
+    for (size_t i = 0; i < this->connections->len; i++) {
+        laik_tcp_socket_free (g_ptr_array_index (this->connections, i));
+    }
+
+    g_ptr_array_unref (this->connections);
+
+    g_free (this);
+}
+
+Laik_Tcp_Server* laik_tcp_server_new (Laik_Tcp_Socket* socket, const size_t limit) {
+    laik_tcp_always (socket);
+
+    g_autoptr (GPtrArray) connections = g_ptr_array_sized_new (1 + limit);
+    g_ptr_array_add (connections, socket);
+
+    Laik_Tcp_Server* this = g_new0 (Laik_Tcp_Server, 1);
+
+    *this = (Laik_Tcp_Server) {
+        .connections = g_steal_pointer (&connections),
+        .limit       = limit,
+    };
+
+    return this;
+}
+
+void laik_tcp_server_store (Laik_Tcp_Server* this, Laik_Tcp_Socket* socket) {
+    laik_tcp_always (this);
+    laik_tcp_always (socket);
+
+    // Make sure we don't exceed the connection limit
+    if (this->limit && this->connections->len >= this->limit) {
+        const int64_t timestamp = g_get_monotonic_time () - 10 * G_TIME_SPAN_MILLISECOND;
+        for (size_t index = 0; index < this->connections->len;) {
+            Laik_Tcp_Socket* candidate = g_ptr_array_index (this->connections, index);
+            if (laik_tcp_socket_get_listening (candidate) || laik_tcp_socket_get_timestamp (candidate) > timestamp) {
+                laik_tcp_debug ("Not removing socket");
+                index++;
+            } else {
+                laik_tcp_debug ("Removing socket");
+                laik_tcp_socket_free (candidate);
+                g_ptr_array_remove_index (this->connections, index);
+            }
+        }
+    }
+
+    if (this->limit && this->connections->len < this->limit) {
+        g_ptr_array_add (this->connections, laik_tcp_socket_touch (socket));
+    } else {
+        laik_tcp_socket_free (socket);
+    }
+}

--- a/src/backends/tcp/server.h
+++ b/src/backends/tcp/server.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <glib.h>    // for G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for int64_t
+#include "errors.h"  // for Laik_Tcp_Errors
+#include "socket.h"  // for Laik_Tcp_Socket
+
+typedef struct Laik_Tcp_Server Laik_Tcp_Server;
+
+__attribute__  ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_server_accept (Laik_Tcp_Server* this, int64_t microseconds);
+
+void laik_tcp_server_free (Laik_Tcp_Server* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Server, laik_tcp_server_free)
+
+__attribute__  ((warn_unused_result))
+Laik_Tcp_Server* laik_tcp_server_new (Laik_Tcp_Socket* socket, size_t limit);
+
+void laik_tcp_server_store (Laik_Tcp_Server* this, Laik_Tcp_Socket* socket);

--- a/src/backends/tcp/socket.c
+++ b/src/backends/tcp/socket.c
@@ -1,0 +1,361 @@
+#include "socket.h"
+#include <endian.h>       // for htole64, le64toh
+#include <errno.h>        // for errno
+#include <glib.h>         // for g_get_monotonic_time, g_malloc0_n, GPtrArray
+#include <netdb.h>        // for getaddrinfo, addrinfo, freeaddrinfo
+#include <netinet/in.h>   // for IPPROTO_TCP
+#include <netinet/tcp.h>  // for TCP_NODELAY
+#include <poll.h>         // for pollfd, poll, POLLNVAL
+#include <stdbool.h>      // for bool, true, false
+#include <stddef.h>       // for NULL, size_t
+#include <stdio.h>        // for snprintf
+#include <string.h>       // for strerror, strsep
+#include <sys/socket.h>   // for setsockopt, sockaddr, accept, bind, connect
+#include <sys/un.h>       // for sockaddr_un, sa_family_t
+#include <unistd.h>       // for close, ssize_t
+#include "debug.h"        // for laik_tcp_always, laik_tcp_debug
+#include "errors.h"       // for laik_tcp_errors_push, Laik_Tcp_Errors
+
+typedef struct addrinfo Laik_Tcp_AddrInfo;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_AddrInfo, freeaddrinfo)
+
+struct Laik_Tcp_Socket {
+    int     fd;
+    short   events;
+    int64_t timestamp;
+};
+
+__attribute__ ((warn_unused_result))
+static bool laik_tcp_socket_receive_raw (Laik_Tcp_Socket* this, void* data, size_t size) {
+    laik_tcp_always (this);
+    laik_tcp_always (data || !size);
+
+    if (size) {
+        return recv (this->fd, data, size, MSG_WAITALL) == (ssize_t) size;
+    } else {
+        return true;
+    }
+}
+
+__attribute__ ((warn_unused_result))
+static bool laik_tcp_socket_send_raw (Laik_Tcp_Socket* this, const void* data, size_t size) {
+    laik_tcp_always (this);
+    laik_tcp_always (data || !size);
+
+    if (size) {
+        return send (this->fd, data, size, MSG_NOSIGNAL) == (ssize_t) size;
+    } else {
+        return true;
+    }
+}
+
+Laik_Tcp_Socket* laik_tcp_socket_accept (Laik_Tcp_Socket* this) {
+    laik_tcp_always (this);
+    laik_tcp_always (laik_tcp_socket_get_listening (this));
+
+    // Accept the connection
+    int fd = accept (this->fd, NULL, NULL);
+    laik_tcp_always (fd >= 0);
+
+    // Create the object
+    Laik_Tcp_Socket* new = g_new0 (Laik_Tcp_Socket, 1);
+
+    // Initialize the object
+    *new = (Laik_Tcp_Socket) {
+        .fd        = fd,
+        .events    = 0,
+        .timestamp = g_get_monotonic_time (),
+    };
+
+    // Return the object
+    return new;
+}
+
+void laik_tcp_socket_destroy (void* this) {
+    laik_tcp_socket_free (this);
+}
+
+void laik_tcp_socket_free (Laik_Tcp_Socket* this) {
+    if (!this) {
+        return;
+    }
+
+    close (this->fd);
+
+    g_free (this);
+}
+
+bool laik_tcp_socket_get_listening (const Laik_Tcp_Socket* this) {
+    int       optval = 0;
+    socklen_t optlen = sizeof (optval);
+
+    int result = getsockopt (this->fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, &optlen);
+    laik_tcp_always (result == 0);
+    (void) result;
+
+    return optval;
+}
+
+int64_t laik_tcp_socket_get_timestamp (const Laik_Tcp_Socket* this) {
+    return this->timestamp;
+}
+
+Laik_Tcp_Socket* laik_tcp_socket_new (Laik_Tcp_SocketType type, const char* address, Laik_Tcp_Errors* errors) {
+    laik_tcp_always (address);
+    laik_tcp_always (errors);
+
+    // Create variables to store the sockaddr struct and its size
+    g_autofree struct sockaddr* socket_address_data = NULL;
+    socklen_t socket_address_size = 0;
+
+    // Split the address on the first white space
+    g_autofree char* duplicate = g_strdup (address);
+    char* remainder  = duplicate;
+    char* first_word = strsep (&remainder, " \t\n");
+
+    // Do we want a TCP socket with host and port or an abstract UNIX socket?
+    if (first_word && remainder) {
+        laik_tcp_debug ("Trying to create a TCP socket with host %s and port %s", first_word, remainder);
+
+        // Create a hints struct for getaddrinfo
+        struct addrinfo hints = {
+            .ai_socktype = SOCK_STREAM,
+        };
+
+        // Create a result variable for getaddrinfo
+        g_autoptr (Laik_Tcp_AddrInfo) addresses = NULL;
+
+        // Call getaddrinfo with the host and port extracted from the address
+        int result = getaddrinfo (first_word, remainder, &hints, &addresses);
+        if (result != 0) {
+            laik_tcp_errors_push (errors, __func__, 0, "getaddrinfo (%s, %s) failed: %s", first_word, remainder, strerror (errno));
+            return NULL;
+        }
+
+        // Fill the socket address variables
+        socket_address_size = addresses->ai_addrlen;
+        socket_address_data = g_memdup (addresses->ai_addr, addresses->ai_addrlen);
+    } else {
+        laik_tcp_debug ("Trying to create an abstract UNIX socket with name %s", address);
+
+        // Create a sockaddr_un struct
+        g_autofree struct sockaddr_un* sockaddr_un = g_new0 (struct sockaddr_un, 1);
+
+        // Fill the sockaddr_un struct
+        sockaddr_un->sun_family = AF_UNIX;
+        const int bytes = snprintf (sockaddr_un->sun_path, sizeof (sockaddr_un->sun_path), "%c%s", 0, address);
+
+        // Check if snprintf failed
+        if (bytes < 0) { 
+            laik_tcp_errors_push (errors, __func__, 1, "snprintf failed while settin up an abstract UNIX socket for address '%s': %s", address, strerror (errno));
+            return NULL;
+        }
+
+        // Check if we exceeded the size. Note that > is correct here, since
+        // abstract UNIX sockets are *not* NUL-terminated. See also unix(7).
+        if ((size_t) bytes > sizeof (sockaddr_un->sun_path)) { 
+            laik_tcp_errors_push (errors, __func__, 2, "Address '%s' is too long for abstract UNIX socket", address);
+            return NULL;
+        }
+
+        // Fill the socket address variables
+        socket_address_size = sizeof (sockaddr_un->sun_family) + bytes;
+        socket_address_data = g_steal_pointer (&sockaddr_un);
+    }
+
+    // Create a suitable socket
+    int fd = socket (socket_address_data->sa_family, SOCK_STREAM, 0);
+    if (fd < 0) {
+        laik_tcp_errors_push (errors, __func__, 3, "Failed to create streaming socket in address family %d: %s", (int) socket_address_data->sa_family, strerror (errno));
+        return NULL;
+    }
+
+    // On TCP server sockets, set some extra options 
+    if (socket_address_data->sa_family == AF_INET || socket_address_data->sa_family == AF_INET6) {
+        // Enable reuse of recently freed ports
+        if (setsockopt (fd, SOL_SOCKET, SO_REUSEADDR, & (int) { 1 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 4, "Failed to set SO_REUSEADDR on socket: %s", strerror (errno));
+            return NULL;
+        }
+
+        // Enable TCP keep alives
+        if (setsockopt (fd, SOL_SOCKET, SO_KEEPALIVE, & (int) { 1 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 5, "Failed to set SO_KEEPALIVETCP_KEEPCNT on socket: %s", strerror (errno));
+            return NULL;
+        }
+
+        // Disable Nagle's algorithm so messages are sent without delays
+        if (setsockopt (fd, IPPROTO_TCP, TCP_NODELAY, & (int) { 1 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 6, "Failed to set TCP_NODELAY on socket: %s", strerror (errno));
+            return NULL;
+        }
+
+        // Sent up to three keep alive probes before dropping the connection
+        if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, & (int) { 3 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 7, "Failed to set TCP_KEEPCNT on socket: %s", strerror (errno));
+            return NULL;
+        }
+
+        // Consider the connection idle after 1 second if inactivity
+        if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, & (int) { 1 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 8, "Failed to set TCP_KEEPIDLE on socket: %s", strerror (errno));
+            return NULL;
+        }
+
+        // On idle connections, send a keep alive probe every second
+        if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, & (int) { 1 }, sizeof (int)) != 0) {
+            laik_tcp_errors_push (errors, __func__, 9, "Failed to set TCP_KEEPINTVL on socket: %s", strerror (errno));
+            return NULL;
+        }
+    }
+
+    // Handle the different socket types
+    if (type == LAIK_TCP_SOCKET_TYPE_CLIENT) {
+        if (connect (fd, socket_address_data, socket_address_size) != 0) {
+            laik_tcp_errors_push (errors, __func__, 10, "Failed to connect to %s: %s", address, strerror (errno));
+            close (fd);
+            return NULL;
+        }
+    } else if (type == LAIK_TCP_SOCKET_TYPE_SERVER) {
+        if (bind (fd, socket_address_data, socket_address_size) != 0) {
+            laik_tcp_errors_push (errors, __func__, 11, "Failed to bind socket to '%s': %s", address, strerror (errno));
+            close (fd);
+            return NULL;
+        }
+
+        if (listen (fd, 10) != 0) {
+            laik_tcp_errors_push (errors, __func__, 12, "Failed to listen on socket: %s", strerror (errno));
+            close (fd);
+            return NULL;
+        }
+    } else {
+        laik_tcp_errors_push (errors, __func__, 13, "Invalid socket type %d", type);
+        return NULL;
+    }
+
+    // Create the object
+    Laik_Tcp_Socket* this = g_new0 (Laik_Tcp_Socket, 1);
+
+    // Initialize the object
+    *this = (Laik_Tcp_Socket) {
+        .fd        = fd,
+        .events    = 0,
+        .timestamp = g_get_monotonic_time (),
+    };
+
+    // Return the object
+    return this;
+}
+
+Laik_Tcp_Socket* laik_tcp_socket_poll (GPtrArray* sockets, const short events, const int64_t microseconds) {
+    laik_tcp_always (sockets);
+
+    // Check if any of the sockets in the array already has the requested event
+    for (size_t i = 0; i < sockets->len; i++) {
+        Laik_Tcp_Socket* current = g_ptr_array_index (sockets, i);
+        if (current->events & events) {
+            laik_tcp_debug ("Found a socket with the requested event already cached");
+            current->events = 0;
+            return current;
+        }
+    }
+
+    // We have to do a poll(2) call, so create and fill a pollfd buffer
+    g_autofree struct pollfd* pollfds = g_new0 (struct pollfd, sockets->len);
+    for (size_t i = 0; i < sockets->len; i++) {
+        const Laik_Tcp_Socket* current = g_ptr_array_index (sockets, i);
+        pollfds[i] = (struct pollfd) { .fd = current->fd, .events = events, .revents = 0 };
+    }
+
+    // Call poll(2)
+    int result = poll (pollfds, sockets->len, microseconds / 1000);
+    laik_tcp_always (result >= 0);
+    (void) result;
+
+    // Store the results of the poll(2) call back into the sockets
+    for (size_t i = 0; i < sockets->len; i++) {
+        laik_tcp_always (!(pollfds[i].revents & POLLNVAL));
+        Laik_Tcp_Socket* current = g_ptr_array_index (sockets, i);
+        current->events = pollfds[i].revents;
+    }
+
+    // Now, check again if we have a matching socket
+    for (size_t i = 0; i < sockets->len; i++) {
+        Laik_Tcp_Socket* current = g_ptr_array_index (sockets, i);
+        if (current->events & events) {
+            laik_tcp_debug ("Found a socket with the requested event after poll(2)-ing");
+            current->events = 0;
+            return current;
+        }
+    }
+
+    // No luck, return failure
+    laik_tcp_debug ("Found no socket with the requested event");
+    return NULL;
+}
+
+GBytes* laik_tcp_socket_receive_bytes (Laik_Tcp_Socket* this) {
+    laik_tcp_always (this);
+
+    uint64_t size;
+
+    if (!laik_tcp_socket_receive_uint64 (this, &size)) {
+        return NULL;
+    }
+
+    g_autofree void* data = g_malloc (size);
+
+    if (!laik_tcp_socket_receive_raw (this, data, size)) {
+        return NULL;
+    }
+
+    return g_bytes_new_take (g_steal_pointer (&data), size);
+}
+
+bool laik_tcp_socket_receive_uint64 (Laik_Tcp_Socket* this, uint64_t* value) {
+    laik_tcp_always (this);
+    laik_tcp_always (value);
+
+    if (!laik_tcp_socket_receive_raw (this, value, sizeof (*value))) {
+        return false;
+    }
+
+    *value = le64toh (*value);
+
+    return true;
+}
+
+bool laik_tcp_socket_send_bytes (Laik_Tcp_Socket* this, GBytes* bytes) {
+    laik_tcp_always (this);
+    laik_tcp_always (bytes);
+
+    size_t size;
+    const void* data = g_bytes_get_data (bytes, &size);
+
+    if (!laik_tcp_socket_send_uint64 (this, size)) {
+        return false;
+    }
+
+    if (!laik_tcp_socket_send_raw (this, data, size)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool laik_tcp_socket_send_uint64 (Laik_Tcp_Socket* this, uint64_t value) {
+    laik_tcp_always (this);
+
+    value = htole64 (value);
+
+    return laik_tcp_socket_send_raw (this, &value, sizeof (value));
+}
+
+Laik_Tcp_Socket* laik_tcp_socket_touch (Laik_Tcp_Socket* this) {
+    laik_tcp_always (this);
+
+    this->timestamp = g_get_monotonic_time ();
+
+    return this;
+}

--- a/src/backends/tcp/socket.h
+++ b/src/backends/tcp/socket.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <glib.h>     // for GBytes, GPtrArray, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for int64_t, uint64_t
+#include "errors.h"   // for Laik_Tcp_Errors
+
+typedef struct Laik_Tcp_Socket Laik_Tcp_Socket;
+
+typedef enum {
+    LAIK_TCP_SOCKET_TYPE_CLIENT = 0,
+    LAIK_TCP_SOCKET_TYPE_SERVER = 1,
+} Laik_Tcp_SocketType;
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_socket_accept (Laik_Tcp_Socket* this);
+
+void laik_tcp_socket_destroy (void* this);
+
+void laik_tcp_socket_free (Laik_Tcp_Socket* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Socket, laik_tcp_socket_free)
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_socket_get_listening (const Laik_Tcp_Socket* this);
+
+__attribute__ ((warn_unused_result))
+int64_t laik_tcp_socket_get_timestamp (const Laik_Tcp_Socket* this);
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_socket_new (Laik_Tcp_SocketType type, const char* address, Laik_Tcp_Errors* errors);
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_socket_poll (GPtrArray* sockets, short events, int64_t microseconds);
+
+__attribute__ ((warn_unused_result))
+GBytes* laik_tcp_socket_receive_bytes (Laik_Tcp_Socket* this);
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_socket_receive_uint64 (Laik_Tcp_Socket* this, uint64_t* value);
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_socket_send_bytes (Laik_Tcp_Socket* this, GBytes* bytes);
+
+__attribute__ ((warn_unused_result))
+bool laik_tcp_socket_send_uint64 (Laik_Tcp_Socket* this, uint64_t value);
+
+__attribute__ ((warn_unused_result))
+Laik_Tcp_Socket* laik_tcp_socket_touch (Laik_Tcp_Socket* this);

--- a/src/backends/tcp/task.c
+++ b/src/backends/tcp/task.c
@@ -1,0 +1,31 @@
+#include "task.h"
+#include <glib.h>   // for g_bytes_ref, g_bytes_unref, g_free, g_malloc0_n
+#include "debug.h"  // for laik_tcp_always
+
+void laik_tcp_task_destroy (void* this) {
+    laik_tcp_task_free (this);
+}
+
+void laik_tcp_task_free (Laik_Tcp_Task* this) {
+    if (!this) {
+        return;
+    }
+
+    g_bytes_unref (this->header);
+
+    g_free (this);
+}
+
+Laik_Tcp_Task* laik_tcp_task_new (int type, size_t peer, GBytes* header) {
+    laik_tcp_always (header);
+
+    Laik_Tcp_Task* this = g_new0 (Laik_Tcp_Task, 1);
+
+    *this = (Laik_Tcp_Task) {
+        .type   = type,
+        .peer   = peer,
+        .header = g_bytes_ref (header),
+    };
+
+    return this;
+}

--- a/src/backends/tcp/task.h
+++ b/src/backends/tcp/task.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <glib.h>    // for GBytes, G_DEFINE_AUTOPTR_CLEANUP_FUNC
+#include <stddef.h>  // for size_t
+
+typedef struct {
+    int     type;
+    size_t  peer;
+    GBytes* header;
+} Laik_Tcp_Task;
+
+void laik_tcp_task_destroy (void* this);
+
+void laik_tcp_task_free (Laik_Tcp_Task* this);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Laik_Tcp_Task, laik_tcp_task_free)
+
+__attribute__  ((warn_unused_result))
+Laik_Tcp_Task* laik_tcp_task_new (int type, size_t peer, GBytes* header);

--- a/src/core.c
+++ b/src/core.c
@@ -6,6 +6,7 @@
 #include <laik-internal.h>
 #include <laik-backend-mpi.h>
 #include <laik-backend-single.h>
+#include <laik-backend-tcp.h>
 
 #include <assert.h>
 #include <stdio.h>
@@ -51,6 +52,12 @@ Laik_Instance* laik_init (int* argc, char*** argv)
         (void) argv;
         return laik_init_single();
     }
+
+#ifdef LAIK_TCP_BACKEND_AVAILABLE
+    if (!override || strcmp (override, "tcp") == 0) {
+        return laik_init_tcp (argc, argv);
+    }
+#endif
 
     // Error: unknown backend wanted
     assert(override != 0);

--- a/tests/tcp/CMakeLists.txt
+++ b/tests/tcp/CMakeLists.txt
@@ -1,0 +1,26 @@
+get_target_property (definitions "laik" "COMPILE_DEFINITIONS")
+
+if ("LAIK_TCP_BACKEND_AVAILABLE" IN_LIST definitions)
+    foreach (test
+        "jac1d_1000_50_10.sh"
+        "jac1d_100.sh"
+        "jac2d_-s_1000.sh"
+        "jac2d_-s_-n_1000.sh"
+        "jac3d_-r_-s_100.sh"
+        "jac3d_-s_100.sh"
+        "jac3d_-s_-n_100.sh"
+        "markov2_40_4.sh"
+        "markov_40_4.sh"
+        "propagation2d_10_10.sh"
+        "spmv2_10_3000.sh"
+        "spmv2_-r_10_3000.sh"
+        "spmv2_-s_2_10_3000.sh"
+        "spmv2_-s_2_-i_10_3000.sh"
+        "spmv_4000.sh"
+        "vsum2.sh"
+        "vsum3.sh"
+        "vsum.sh"
+    )
+        add_test ("tcp/${test}" "${CMAKE_CURRENT_SOURCE_DIR}/${test}")
+    endforeach ()
+endif ()

--- a/tests/tcp/common.sh
+++ b/tests/tcp/common.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -eux
+
+run()(
+    IFS='_'
+    idx="0"
+
+    while [ "${idx}" -lt "${OMPI_COMM_WORLD_SIZE}" ]; do
+        ../../examples/${1} &
+        idx="$((idx + 1))"
+    done
+
+    wait
+)
+
+dir="`dirname -- "${0}"`"
+name="`basename -- "${0%.sh}"`"
+
+export LAIK_BACKEND='tcp'
+export OMPI_COMM_WORLD_SIZE='4'
+
+if [ -f "${dir}/${name}.unsorted" ]; then
+    run "${name}" | diff --unified -- "${dir}/${name}.unsorted" -
+elif [ -f "${dir}/${name}.sorted" ]; then
+    run "${name}" | LC_ALL='C' sort | diff --unified -- "${dir}/${name}.sorted" -
+else
+    exit 1
+fi

--- a/tests/tcp/jac1d_100.sh
+++ b/tests/tcp/jac1d_100.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac1d_100.unsorted
+++ b/tests/tcp/jac1d_100.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac1d-100.expected

--- a/tests/tcp/jac1d_1000_50_10.sh
+++ b/tests/tcp/jac1d_1000_50_10.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac1d_1000_50_10.unsorted
+++ b/tests/tcp/jac1d_1000_50_10.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac1d-1000-repart.expected

--- a/tests/tcp/jac2d_-s_-n_1000.sh
+++ b/tests/tcp/jac2d_-s_-n_1000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac2d_-s_-n_1000.unsorted
+++ b/tests/tcp/jac2d_-s_-n_1000.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac2dn-1000.expected

--- a/tests/tcp/jac2d_-s_1000.sh
+++ b/tests/tcp/jac2d_-s_1000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac2d_-s_1000.unsorted
+++ b/tests/tcp/jac2d_-s_1000.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac2d-1000.expected

--- a/tests/tcp/jac3d_-r_-s_100.sh
+++ b/tests/tcp/jac3d_-r_-s_100.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac3d_-r_-s_100.unsorted
+++ b/tests/tcp/jac3d_-r_-s_100.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac3d-100.expected

--- a/tests/tcp/jac3d_-s_-n_100.sh
+++ b/tests/tcp/jac3d_-s_-n_100.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac3d_-s_-n_100.unsorted
+++ b/tests/tcp/jac3d_-s_-n_100.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac3dn-100.expected

--- a/tests/tcp/jac3d_-s_100.sh
+++ b/tests/tcp/jac3d_-s_100.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/jac3d_-s_100.unsorted
+++ b/tests/tcp/jac3d_-s_100.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-jac3d-100.expected

--- a/tests/tcp/markov2_40_4.sh
+++ b/tests/tcp/markov2_40_4.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/markov2_40_4.unsorted
+++ b/tests/tcp/markov2_40_4.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-markov2-40-4.expected

--- a/tests/tcp/markov_40_4.sh
+++ b/tests/tcp/markov_40_4.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/markov_40_4.unsorted
+++ b/tests/tcp/markov_40_4.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-markov-40-4.expected

--- a/tests/tcp/propagation2d_10_10.sh
+++ b/tests/tcp/propagation2d_10_10.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/propagation2d_10_10.unsorted
+++ b/tests/tcp/propagation2d_10_10.unsorted
@@ -1,0 +1,1 @@
+../mpi/test-propagation2d-10.expected

--- a/tests/tcp/spmv2_-r_10_3000.sh
+++ b/tests/tcp/spmv2_-r_10_3000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/spmv2_-r_10_3000.sorted
+++ b/tests/tcp/spmv2_-r_10_3000.sorted
@@ -1,0 +1,1 @@
+../mpi/test-spmv2.expected

--- a/tests/tcp/spmv2_-s_2_-i_10_3000.sh
+++ b/tests/tcp/spmv2_-s_2_-i_10_3000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/spmv2_-s_2_-i_10_3000.sorted
+++ b/tests/tcp/spmv2_-s_2_-i_10_3000.sorted
@@ -1,0 +1,1 @@
+../mpi/test-spmv2.expected

--- a/tests/tcp/spmv2_-s_2_10_3000.sh
+++ b/tests/tcp/spmv2_-s_2_10_3000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/spmv2_-s_2_10_3000.sorted
+++ b/tests/tcp/spmv2_-s_2_10_3000.sorted
@@ -1,0 +1,1 @@
+../mpi/test-spmv2.expected

--- a/tests/tcp/spmv2_10_3000.sh
+++ b/tests/tcp/spmv2_10_3000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/spmv2_10_3000.sorted
+++ b/tests/tcp/spmv2_10_3000.sorted
@@ -1,0 +1,1 @@
+../mpi/test-spmv2.expected

--- a/tests/tcp/spmv_4000.sh
+++ b/tests/tcp/spmv_4000.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/spmv_4000.sorted
+++ b/tests/tcp/spmv_4000.sorted
@@ -1,0 +1,1 @@
+../mpi/test-spmv.expected

--- a/tests/tcp/vsum.sh
+++ b/tests/tcp/vsum.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/vsum.sorted
+++ b/tests/tcp/vsum.sorted
@@ -1,0 +1,1 @@
+../mpi/test-vsum.expected

--- a/tests/tcp/vsum2.sh
+++ b/tests/tcp/vsum2.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/vsum2.sorted
+++ b/tests/tcp/vsum2.sorted
@@ -1,0 +1,1 @@
+../mpi/test-vsum2.expected

--- a/tests/tcp/vsum3.sh
+++ b/tests/tcp/vsum3.sh
@@ -1,0 +1,1 @@
+common.sh

--- a/tests/tcp/vsum3.sorted
+++ b/tests/tcp/vsum3.sorted
@@ -1,0 +1,1 @@
+../mpi/test-vsum.expected


### PR DESCRIPTION
This is the inital version of the TCP backend. It currently emulates the MPI send/recv API so that ```backend-mpi.c``` can be reused. As of now, this builds only with meson (and consequently this PR contains the meson patch), but I am working on a CMake3 PR for LAIK and will port the TCP backend over once this is done.