### PR TITLE
examples/.gitignore: Don't ignore *.txt files since we need those for…

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,5 +1,4 @@
 *.dSYM
-*.txt
 *.csv
 *.out
 vsum


### PR DESCRIPTION
… CMake.

CMake uses "CMakeLists.txt" as it's default configuration file, so ignoring
all *.txt files would lead to problems here.