### PR TITLE
src/backend-mpi.c: Mark all symbols not declared in the header file a…

### DIFF
--- a/src/backend-mpi.c
+++ b/src/backend-mpi.c
@@ -37,14 +37,14 @@ void laik_mpi_finalize() {}
 
 // forward decls, types/structs , global variables
 
-void laik_mpi_finalize();
-Laik_TransitionPlan* laik_mpi_prepare(Laik_Data*, Laik_Transition*);
-void laik_mpi_cleanup(Laik_TransitionPlan*);
-void laik_mpi_exec(Laik_Data* d, Laik_Transition* t, Laik_TransitionPlan* p,
+static void laik_mpi_finalize();
+static Laik_TransitionPlan* laik_mpi_prepare(Laik_Data*, Laik_Transition*);
+static void laik_mpi_cleanup(Laik_TransitionPlan*);
+static void laik_mpi_exec(Laik_Data* d, Laik_Transition* t, Laik_TransitionPlan* p,
                    Laik_MappingList* from, Laik_MappingList* to);
-void laik_mpi_wait(Laik_TransitionPlan*, int mapNo);
-bool laik_mpi_probe(Laik_TransitionPlan* p, int mapNo);
-void laik_mpi_updateGroup(Laik_Group*);
+static void laik_mpi_wait(Laik_TransitionPlan*, int mapNo);
+static bool laik_mpi_probe(Laik_TransitionPlan* p, int mapNo);
+static void laik_mpi_updateGroup(Laik_Group*);
 
 // C guarantees that unset function pointers are NULL
 static Laik_Backend laik_backend_mpi = {
@@ -152,24 +152,24 @@ Laik_Instance* laik_init_mpi(int* argc, char*** argv)
     return inst;
 }
 
-MPIData* mpiData(Laik_Instance* i)
+static MPIData* mpiData(Laik_Instance* i)
 {
     return (MPIData*) i->backend_data;
 }
 
-MPIGroupData* mpiGroupData(Laik_Group* g)
+static MPIGroupData* mpiGroupData(Laik_Group* g)
 {
     return (MPIGroupData*) g->backend_data;
 }
 
-void laik_mpi_finalize()
+static void laik_mpi_finalize()
 {
     if (mpiData(mpi_instance)->didInit)
         MPI_Finalize();
 }
 
 // update backend specific data for group if needed
-void laik_mpi_updateGroup(Laik_Group* g)
+static void laik_mpi_updateGroup(Laik_Group* g)
 {
     // calculate MPI communicator for group <g>
     // TODO: only supports shrinking of parent for now
@@ -220,9 +220,9 @@ struct _Laik_TransitionPlan {
     Laik_Data* data;
     Laik_Transition* transition;
 };
-Laik_TransitionPlan plan = {0,0};
+static Laik_TransitionPlan plan = {0,0};
 
-Laik_TransitionPlan* laik_mpi_prepare(Laik_Data* d, Laik_Transition* t)
+static Laik_TransitionPlan* laik_mpi_prepare(Laik_Data* d, Laik_Transition* t)
 {
     // only one prepared plan allowed in this backend driver (for now)
     assert(plan.data == 0);
@@ -232,13 +232,13 @@ Laik_TransitionPlan* laik_mpi_prepare(Laik_Data* d, Laik_Transition* t)
     return &plan;
 }
 
-void laik_mpi_cleanup(Laik_TransitionPlan* p)
+static void laik_mpi_cleanup(Laik_TransitionPlan* p)
 {
     // the plan object <p> can be reused to prepare another plan
     p->data = 0;
 }
 
-void laik_mpi_wait(Laik_TransitionPlan* p, int mapNo)
+static void laik_mpi_wait(Laik_TransitionPlan* p, int mapNo)
 {
     // required due to interface signature
     (void) p;
@@ -247,7 +247,7 @@ void laik_mpi_wait(Laik_TransitionPlan* p, int mapNo)
     // nothing to wait for: this backend driver currently is synchronous
 }
 
-bool laik_mpi_probe(Laik_TransitionPlan* p, int mapNo)
+static bool laik_mpi_probe(Laik_TransitionPlan* p, int mapNo)
 {
     // required due to interface signature
     (void) p;
@@ -258,7 +258,7 @@ bool laik_mpi_probe(Laik_TransitionPlan* p, int mapNo)
 }
 
 
-void laik_mpi_exec(Laik_Data *d, Laik_Transition *t, Laik_TransitionPlan* p,
+static void laik_mpi_exec(Laik_Data *d, Laik_Transition *t, Laik_TransitionPlan* p,
                    Laik_MappingList* fromList, Laik_MappingList* toList)
 {
     if (p) {


### PR DESCRIPTION
…s static.

This is good practice as it avoids potential name conflicts and allows the
compiler to omit code generation for those functions if they are fully inlined.