### PR TITLE
Add a new backend which simply redirects to the (compile-time) default backend and make the examples use it.

### DIFF
--- a/examples/c++/raytracer.cpp
+++ b/examples/c++/raytracer.cpp
@@ -43,11 +43,7 @@
 #include <cstring>
 
 extern "C" {
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 }
 
 typedef struct _programops{
@@ -264,11 +260,7 @@ Vec3f trace(
 
 int main(int argc, char **argv) 
 { 
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
     laik_enable_profiling(inst);
     

--- a/examples/jac1d.c
+++ b/examples/jac1d.c
@@ -18,11 +18,7 @@
  * 1d Jacobi example.
  */
 
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,11 +37,7 @@ double getTW(int rank, const void* userData)
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     int ksize = 0;

--- a/examples/jac2d.c
+++ b/examples/jac2d.c
@@ -18,11 +18,7 @@
  * 2d Jacobi example.
  */
 
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -43,11 +39,7 @@ double getTW(int rank, const void* userData)
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     int size = 0;

--- a/examples/jac3d.c
+++ b/examples/jac3d.c
@@ -18,11 +18,7 @@
  * 3d Jacobi example.
  */
 
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,11 +85,7 @@ void setBoundary(int size, Laik_AccessPhase *pWrite, Laik_Data* dWrite)
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     int size = 0;

--- a/examples/markov.c
+++ b/examples/markov.c
@@ -18,11 +18,7 @@
  * Distributed Markov chain example.
  */
 
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -228,11 +224,7 @@ Laik_Data* runIndirection(MGraph* mg, int miter,
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     int n = 1000000;

--- a/examples/markov2.c
+++ b/examples/markov2.c
@@ -18,11 +18,7 @@
  * Distributed Markov chain example, using LAIK reduction.
  */
 
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -262,11 +258,7 @@ Laik_Data* runIndirection(MGraph* mg, int miter,
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     world = laik_world(inst);
 
     int n = 100000;

--- a/examples/propagation1d.c
+++ b/examples/propagation1d.c
@@ -1,8 +1,4 @@
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -38,14 +34,7 @@ Laik_Partitioner* laik_new_lulesh_partitioner_1d()
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    (void) argc;
-    (void) argv;
-
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     #ifdef DBG

--- a/examples/propagation2d.c
+++ b/examples/propagation2d.c
@@ -1,16 +1,10 @@
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <math.h>
-
-#include "laik.h"
 
 // application specific method to calculate border nodes for an element
 // for 2d lulesh, each element has 4 neighbour nodes
@@ -236,11 +230,7 @@ void apply_boundary_condition(Laik_Data* data, Laik_AccessPhase* ap,
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     #ifdef DBG

--- a/examples/spmv.c
+++ b/examples/spmv.c
@@ -18,13 +18,7 @@
  * SPMV example.
  */
 
-#include "laik.h"
-
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,11 +47,7 @@ double getEW(Laik_Index* i, const void* d)
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     int size = 0;

--- a/examples/spmv2.c
+++ b/examples/spmv2.c
@@ -18,13 +18,7 @@
  * SPMV example.
  */
 
-#include "laik.h"
-
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -118,11 +112,7 @@ void help(char* err)
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
 #ifdef USE_EXT_INTF

--- a/examples/vsum.c
+++ b/examples/vsum.c
@@ -26,17 +26,10 @@
  * distribute the data when switching between partitionings.
  */
 
-#include "laik.h"
-
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <assert.h>
-
 
 // for element-wise weighted partitioning: same as index
 double getEW(Laik_Index* i, const void* d)
@@ -51,14 +44,7 @@ double getTW(int r, const void* d) { return ((long int)d == r) ? 0.0 : 1.0; }
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    (void) argc;
-    (void) argv;
-
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     laik_set_phase(inst, 0, "init", NULL);

--- a/examples/vsum2.c
+++ b/examples/vsum2.c
@@ -22,13 +22,7 @@
  * set the cycle count for the block partitioner to 2.
  */
 
-#include "laik.h"
-
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <assert.h>
@@ -46,14 +40,7 @@ double getTW(int r, const void* d) { return ((long int)d == r) ? 0.0 : 1.0; }
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    (void) argc;
-    (void) argv;
-
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     laik_set_phase(inst, 0, "init", NULL);

--- a/examples/vsum3.c
+++ b/examples/vsum3.c
@@ -26,17 +26,10 @@
  * distribute the data when switching between partitionings.
  */
 
-#include "laik.h"
-
-#ifdef USE_MPI
-#include "laik-backend-mpi.h"
-#else
-#include "laik-backend-single.h"
-#endif
+#include <laik.h>
 
 #include <stdio.h>
 #include <assert.h>
-
 
 // for element-wise weighted partitioning: same as index
 double getEW(Laik_Index* i, const void* d)
@@ -51,14 +44,7 @@ double getTW(int r, const void* d) { return ((long int)d == r) ? 0.0 : 1.0; }
 
 int main(int argc, char* argv[])
 {
-#ifdef USE_MPI
-    Laik_Instance* inst = laik_init_mpi(&argc, &argv);
-#else
-    (void) argc;
-    (void) argv;
-
-    Laik_Instance* inst = laik_init_single();
-#endif
+    Laik_Instance* inst = laik_init (&argc, &argv);
     Laik_Group* world = laik_world(inst);
 
     laik_set_phase(inst, 0, "init", NULL);

--- a/include/laik/core.h
+++ b/include/laik/core.h
@@ -159,5 +159,8 @@ void laik_log_append(const char* msg, ...);
 // finalize the log message build with laik_log_begin/append and print it
 void laik_log_flush(const char* msg, ...);
 
+// Provide a generic LAIK initialization function for programs which don't care
+// which backend LAIK actually uses (e.g. the examples).
+Laik_Instance* laik_init (int* argc, char*** argv);
 
 #endif // _LAIK_CORE_H_

--- a/src/core.c
+++ b/src/core.c
@@ -3,7 +3,9 @@
  * Copyright (c) 2017 Josef Weidendorfer
  */
 
-#include "laik-internal.h"
+#include <laik-internal.h>
+#include <laik-backend-mpi.h>
+#include <laik-backend-single.h>
 
 #include <assert.h>
 #include <stdio.h>
@@ -703,4 +705,15 @@ void laik_kv_sync(Laik_Instance* inst)
 
     assert(b && b->sync);
     (b->sync)(inst);
+}
+
+// generic LAIK init function
+Laik_Instance* laik_init (int* argc, char*** argv) {
+    #ifdef USE_MPI
+    return laik_init_mpi (argc, argv);
+    #else
+    (void) argc;
+    (void) argv;
+    return laik_init_single ();
+    #endif
 }


### PR DESCRIPTION
This removes the ugly and duplicated ifdef-code from the examples and instead centralizes it in one place. Furthermore, we can extend the default backend in the future to e.g. honour a LAIK_BACKEND environment variable without changing the examples again.