### PR TITLE
core: Mark all Laik_Backend pointers as const.

### DIFF
--- a/include/laik/core-internal.h
+++ b/include/laik/core-internal.h
@@ -61,7 +61,7 @@ struct _Laik_Instance {
     // to synchronize internal data among tasks
     Laik_KVNode* kvstore;
 
-    Laik_Backend* backend;
+    const Laik_Backend* backend;
     void* backend_data;
 
     Laik_Space* firstSpaceForInstance;

--- a/include/laik/core.h
+++ b/include/laik/core.h
@@ -41,7 +41,7 @@ typedef struct _Laik_Group Laik_Group;
  *********************************************************************/
 
 // allocate space for a new LAIK instance
-Laik_Instance* laik_new_instance(Laik_Backend* b, int size, int myid,
+Laik_Instance* laik_new_instance(const Laik_Backend* b, int size, int myid,
                                  char* location, void* data);
 
 //! shut down communication and free resources of this instance

--- a/src/core.c
+++ b/src/core.c
@@ -73,7 +73,7 @@ char* laik_mylocation(Laik_Instance* inst)
 }
 
 // allocate space for a new LAIK instance
-Laik_Instance* laik_new_instance(Laik_Backend* b,
+Laik_Instance* laik_new_instance(const Laik_Backend* b,
                                  int size, int myid,
                                  char* location, void* data)
 {
@@ -701,7 +701,7 @@ bool laik_kv_remove(Laik_KVNode* n, char* path)
 // synchronize KV store
 void laik_kv_sync(Laik_Instance* inst)
 {
-    Laik_Backend* b = inst->backend;
+    const Laik_Backend* b = inst->backend;
 
     assert(b && b->sync);
     (b->sync)(inst);


### PR DESCRIPTION
There's no valid reason to ever change the content of a Laik_Backend struct
after it has been set up by the backend's initialization function, so make
the compiler ensure that we actually can't.