### PR TITLE
src/data.c: Also set up the pack/unpack functions on 1d layouts.

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -325,6 +325,8 @@ Laik_Layout* laik_new_layout_def_1d()
         l->stride[1] = 0;
         l->stride[2] = 0;
         l->isFixed = false; // this prohibits free() on layout
+        l->pack = laik_pack_def;
+        l->unpack = laik_unpack_def;
     }
     return l;
 }


### PR DESCRIPTION
This allows backends to not know at all how to serialize data and just leave
this to the pack/unpack functions. Yes, for 1d layouts this is inefficient, but
it's of course still possible to not use the pack/unpack functions here.