### PR TITLE
[RFC] src/backend-mpi.c: Include and sort the tasks by child ID rather than…

### DIFF
--- a/src/backend-mpi.c
+++ b/src/backend-mpi.c
@@ -185,9 +185,8 @@ static void laik_mpi_updateGroup(Laik_Group* g)
     laik_log(1, "MPI Comm_split: old myid %d => new myid %d",
              g->parent->myid, g->fromParent[g->parent->myid]);
 
-    MPI_Comm_split(gdParent->comm,
-                   (g->fromParent[g->parent->myid] < 0) ? MPI_UNDEFINED : 0,
-                   g->parent->myid, &(gd->comm));
+    MPI_Comm_split(gdParent->comm, g->myid < 0 ? MPI_UNDEFINED : 0, g->myid,
+        &(gd->comm));
 }
 
 static


### PR DESCRIPTION
… parent ID when updating the group.

Our caller (e.g. laik_new_shrinked_group) must have set up the "myid" field
correctly anyway, so we may as well use it. The main advantage is, that this
makes the code a lot easier to understand since we avoid the indirection of
the fromParent mapping.

**Disclaimer: I am not entirely sure, that this is correct. From my understanding of core.c, it should be, but please also view this PR as a kind of confirmation question!**