### PR TITLE
.travis.yml: Bump the smallest tested GCC version from 4.7 to 4.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
  - IMG="debian:stretch" PKG="clang-3.9 libomp-dev" CC="clang-3.9" CXX="clang++-3.9"
  - IMG="debian:stretch" PKG="gcc-6 g++-6"          CC="gcc-6"     CXX="g++-6"
  - IMG="ubuntu:xenial"  PKG="clang-4.0 libomp-dev" CC="clang-4.0" CXX="clang++-4.0"
- - IMG="ubuntu:xenial"  PKG="gcc-4.7 g++-4.7"      CC="gcc-4.7"   CXX="g++-4.7"
+ - IMG="ubuntu:xenial"  PKG="gcc-4.8 g++-4.8"      CC="gcc-4.8"   CXX="g++-4.8"
  - IMG="ubuntu:xenial"  PKG="gcc-5 g++-5"          CC="gcc-5"     CXX="g++-5"
 
 script:


### PR DESCRIPTION
The reason for this is mainly that 4.8 supports the "-Wpedantic" option [0],
while 4.7 doesn't [1] (it only supports "-pedantic", which has a slightly
different meaning on clang).

[0] https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Warning-Options.html
[1] https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Warning-Options.html