### PR TITLE
src/core.c: Make laik_new_instance() create a first group with the sa…

### DIFF
--- a/src/backend-mpi.c
+++ b/src/backend-mpi.c
@@ -100,22 +100,6 @@ Laik_Instance* laik_init_mpi(int* argc, char*** argv)
 
     sprintf(inst->guid, "%d", rank);
 
-    // group world
-
-    MPIGroupData* gd = malloc(sizeof(MPIGroupData));
-    if (!gd) {
-        laik_panic("Out of memory allocating MPIGroupData object");
-        exit(1); // not actually needed, laik_panic never returns
-    }
-    gd->comm = MPI_COMM_WORLD;
-
-    Laik_Group* g = laik_create_group(inst);
-    g->inst = inst;
-    g->gid = 0;
-    g->size = inst->size;
-    g->myid = inst->myid;
-    g->backend_data = gd;
-
     laik_log(1, "MPI backend initialized (location '%s', pid %d)\n",
              inst->mylocation, (int) getpid());
 

--- a/src/backend-single.c
+++ b/src/backend-single.c
@@ -31,13 +31,6 @@ Laik_Instance* laik_init_single()
     Laik_Instance* inst;
     inst = laik_new_instance(&laik_backend_single, 1, 0, "local", 0);
 
-    // group world
-    Laik_Group* g = laik_create_group(inst);
-    g->inst = inst;
-    g->gid = 0;
-    g->size = 1;
-    g->myid = 0;
-
     laik_log(1, "Single backend initialized\n");
 
     single_instance = inst;

--- a/src/core.c
+++ b/src/core.c
@@ -136,6 +136,13 @@ Laik_Instance* laik_new_instance(const Laik_Backend* b,
         stdout = laik_logfile;
     }
 
+    // Create a group in this instance with same parameters as the instance.
+    // Since it's the first group, this is what laik_world() will return.
+    Laik_Group* first_group = laik_create_group (instance);
+    first_group->size         = size;
+    first_group->myid         = myid;
+    first_group->backend_data = data;
+
     return instance;
 }
 


### PR DESCRIPTION
…me parameters as the instance.

This means, that the individual backend's laik_init_*() functions only
have to create the instance (as the type signature suggests) and can be
oblivious to the concept of groups.