### PR TITLE
Mark some of LAIK's function parameters as const.

### DIFF
--- a/include/laik/data-internal.h
+++ b/include/laik/data-internal.h
@@ -129,13 +129,13 @@ struct _Laik_Layout {
     // called iteratively by backends, using <idx> to remember position
     // accross multiple calls. <idx> must be set first to index at beginning.
     // returns the number of elements written (or 0 if finished)
-    int (*pack)(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+    int (*pack)(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                 char* buf, int size);
 
     // unpack data from <buf> with <size> bytes length into given slice of
     // memory space provided by mapping, incrementing index accordingly.
     // returns number of elements unpacked.
-    int (*unpack)(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+    int (*unpack)(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                 char* buf, int size);
 };
 

--- a/include/laik/debug.h
+++ b/include/laik/debug.h
@@ -32,7 +32,7 @@
 void laik_log_IntList(int len, int* list);
 void laik_log_PrettyInt(uint64_t v);
 void laik_log_Space(Laik_Space* spc);
-void laik_log_Index(int dims, Laik_Index* idx);
+void laik_log_Index(int dims, const Laik_Index* idx);
 void laik_log_Slice(int dims, Laik_Slice* slc);
 void laik_log_Reduction(Laik_ReductionOperation op);
 void laik_log_DataFlow(Laik_DataFlow flow);

--- a/include/laik/space-internal.h
+++ b/include/laik/space-internal.h
@@ -30,7 +30,7 @@
 
 void laik_set_index(Laik_Index* i, int64_t i1, int64_t i2, int64_t i3);
 void laik_add_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2);
-void laik_sub_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2);
+void laik_sub_index(Laik_Index* res, const Laik_Index* src1, const Laik_Index* src2);
 
 
 struct _Laik_Space {

--- a/include/laik/space.h
+++ b/include/laik/space.h
@@ -159,7 +159,7 @@ void laik_set_space_name(Laik_Space* s, char* n);
 void laik_change_space_1d(Laik_Space* s, int64_t from1, int64_t to1);
 
 // are the indexes equal?
-bool laik_index_isEqual(int dims, Laik_Index* i1, Laik_Index* i2);
+bool laik_index_isEqual(int dims, const Laik_Index* i1, const Laik_Index* i2);
 
 // is the given slice empty?
 bool laik_slice_isEmpty(int dims, Laik_Slice* slc);
@@ -171,16 +171,16 @@ Laik_Slice* laik_slice_intersect(int dims, const Laik_Slice* s1, const Laik_Slic
 void laik_slice_expand(int dims, Laik_Slice* dst, Laik_Slice* src);
 
 // is slice <slc1> contained in <slc2>?
-bool laik_slice_within_slice(int dims, Laik_Slice* slc1, Laik_Slice* slc2);
+bool laik_slice_within_slice(int dims, const Laik_Slice* slc1, const Laik_Slice* slc2);
 
 // is slice within space borders?
-bool laik_slice_within_space(Laik_Slice* slc, Laik_Space* sp);
+bool laik_slice_within_space(const Laik_Slice* slc, const Laik_Space* sp);
 
 // are the slices equal?
 bool laik_slice_isEqual(int dims, Laik_Slice* s1, Laik_Slice* s2);
 
 // number of indexes in the slice
-uint64_t laik_slice_size(int dims, Laik_Slice* s);
+uint64_t laik_slice_size(int dims, const Laik_Slice* s);
 
 // get the index slice covered by the space
 const Laik_Slice* laik_space_asslice(Laik_Space* space);

--- a/src/data.c
+++ b/src/data.c
@@ -12,9 +12,9 @@
 #include <stdio.h>
 
 // forward decl
-int laik_pack_def(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+int laik_pack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                 char* buf, int size);
-int laik_unpack_def(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+int laik_unpack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                   char* buf, int size);
 
 // initialize the LAIK data module, called from laik_new_instance
@@ -1274,7 +1274,7 @@ int64_t laik_offset(Laik_Index* idx, Laik_Layout* l)
 }
 
 // pack/unpack routines for default layout
-int laik_pack_def(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+int laik_pack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                   char* buf, int size)
 {
     int elemsize = m->data->elemsize;
@@ -1396,7 +1396,7 @@ int laik_pack_def(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
     return count;
 }
 
-int laik_unpack_def(Laik_Mapping* m, Laik_Slice* s, Laik_Index* idx,
+int laik_unpack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                     char* buf, int size)
 {
     int elemsize = m->data->elemsize;

--- a/src/debug.c
+++ b/src/debug.c
@@ -66,7 +66,7 @@ void laik_log_Space(Laik_Space* spc)
     }
 }
 
-void laik_log_Index(int dims, Laik_Index* idx)
+void laik_log_Index(int dims, const Laik_Index* idx)
 {
     int64_t i1 = idx->i[0];
     int64_t i2 = idx->i[1];

--- a/src/space.c
+++ b/src/space.c
@@ -35,7 +35,7 @@ void laik_add_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2)
     res->i[2] = src1->i[2] + src2->i[2];
 }
 
-void laik_sub_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2)
+void laik_sub_index(Laik_Index* res, const Laik_Index* src1, const Laik_Index* src2)
 {
     res->i[0] = src1->i[0] - src2->i[0];
     res->i[1] = src1->i[1] - src2->i[1];
@@ -43,7 +43,7 @@ void laik_sub_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2)
 }
 
 
-bool laik_index_isEqual(int dims, Laik_Index* i1, Laik_Index* i2)
+bool laik_index_isEqual(int dims, const Laik_Index* i1, const Laik_Index* i2)
 {
     if (i1->i[0] != i2->i[0]) return false;
     if (dims == 1) return true;
@@ -124,7 +124,7 @@ void laik_slice_expand(int dims, Laik_Slice* dst, Laik_Slice* src)
 }
 
 // is slice <slc1> contained in <slc2>?
-bool laik_slice_within_slice(int dims, Laik_Slice* slc1, Laik_Slice* slc2)
+bool laik_slice_within_slice(int dims, const Laik_Slice* slc1, const Laik_Slice* slc2)
 {
     if (slc1->from.i[0] < slc1->to.i[0]) {
         // not empty
@@ -149,7 +149,7 @@ bool laik_slice_within_slice(int dims, Laik_Slice* slc1, Laik_Slice* slc2)
 }
 
 // is slice within space borders?
-bool laik_slice_within_space(Laik_Slice* slc, Laik_Space* sp)
+bool laik_slice_within_space(const Laik_Slice* slc, const Laik_Space* sp)
 {
     return laik_slice_within_slice(sp->dims, slc, &(sp->s));
 }
@@ -164,7 +164,7 @@ bool laik_slice_isEqual(int dims, Laik_Slice* s1, Laik_Slice* s2)
 
 
 // number of indexes in the slice
-uint64_t laik_slice_size(int dims, Laik_Slice* s)
+uint64_t laik_slice_size(int dims, const Laik_Slice* s)
 {
     uint64_t size = s->to.i[0] - s->from.i[0];
     if (dims > 1) {


### PR DESCRIPTION
This commit allows backends to mark the send/receive ops as const in
turn. Unfortunately, due to the virulent nature of "const", this commit
can't really be made any smaller.