### PR TITLE
src/{core,profiling}.c: Match every va_start() call with a va_end() c…

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -424,6 +424,7 @@ void laik_log_append(const char* msg, ...)
     va_list args;
     va_start(args, msg);
     log_append(msg, args);
+    va_end(args);
 }
 
 static
@@ -533,6 +534,7 @@ void laik_log_flush(const char* msg, ...)
         va_list args;
         va_start(args, msg);
         log_append(msg, args);
+        va_end(args);
     }
 
     log_flush();
@@ -545,6 +547,7 @@ void laik_log(Laik_LogLevel l, const char* msg, ...)
     va_list args;
     va_start(args, msg);
     log_append(msg, args);
+    va_end(args);
 
     log_flush();
 }

--- a/src/profiling.c
+++ b/src/profiling.c
@@ -236,6 +236,7 @@ void laik_profile_printf(const char* msg, ...)
         va_list args;
         va_start(args, msg);
         vfprintf((FILE*)laik_profinst->profiling->profile_file, msg, args);
+        va_end(args);
     }
 }
 


### PR DESCRIPTION
…all as required by stdarg(3).