### PR TITLE
[RFC] external/profiling/profilagent.c: Add missing initialization of the "count" out parameter in the get_counters() function.

### DIFF
--- a/external/profiling/profilagent.c
+++ b/external/profiling/profilagent.c
@@ -113,6 +113,8 @@ void get_counters(
         strncpy(data[i].name, events[i], MAX_PERF_NAME_LENGTH);
         data[i].value = values[i];
     }
+
+    *count = ev_count;
 }
 
 


### PR DESCRIPTION
Looking at the only caller (```prof_get_all_counters()``` in the same file), this seems to be the right thing to do, but @twittidai as the original author should probably review this first!

PS: This was discovered while trying to build LAIK with ```NDEBUG``` set. This failed miserably since in a lot of places ```assert()``` calls aren't just used to detect programming errors, but at least it uncovered this bug!