### PR TITLE
include/laik{,-internal}.h: Define proper _INSIDE_ macros and enforce…

### DIFF
--- a/include/laik-internal.h
+++ b/include/laik-internal.h
@@ -18,6 +18,8 @@
 #ifndef _LAIK_INTERNAL_H_
 #define _LAIK_INTERNAL_H_
 
+#define _LAIK_INTERNAL_H_INSIDE_
+
 #include "laik.h"
 
 // also include all internal LAIK headers
@@ -30,5 +32,7 @@
 #include "laik/program-internal.h"
 #include "laik/profiling-internal.h"
 #include "laik/ext.h"
+
+#undef _LAIK_INTERNAL_H_INSIDE_
 
 #endif // _LAIK_INTERNAL_H_

--- a/include/laik.h
+++ b/include/laik.h
@@ -18,6 +18,8 @@
 #ifndef _LAIK_H_
 #define _LAIK_H_
 
+#define _LAIK_H_INSIDE_
+
 // include headers of all Laik modules (without LAIK backends)
 #include "laik/core.h"
 #include "laik/space.h"
@@ -26,5 +28,7 @@
 #include "laik/program.h"
 #include "laik/profiling.h"
 #include "laik/ext.h"
+
+#undef _LAIK_H_INSIDE_
 
 #endif // _LAIK_H_

--- a/include/laik/agent.h
+++ b/include/laik/agent.h
@@ -21,6 +21,10 @@
 #ifndef _LAIK_AGENT_H_
 #define _LAIK_AGENT_H_
 
+#ifndef _LAIK_H_INSIDE_
+#error "include laik.h instead"
+#endif
+
 #define MAX_UID_LENGTH 64
 #define MAX_FAILED_BUFFER 32
 

--- a/include/laik/backend.h
+++ b/include/laik/backend.h
@@ -24,7 +24,7 @@
 // Do not include this file in LAIK applications!
 //
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/core-internal.h
+++ b/include/laik/core-internal.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_CORE_INTERNAL_H_
 #define _LAIK_CORE_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/core.h
+++ b/include/laik/core.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_CORE_H_
 #define _LAIK_CORE_H_
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 

--- a/include/laik/data-internal.h
+++ b/include/laik/data-internal.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_DATA_INTERNAL_H_
 #define _LAIK_DATA_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/data.h
+++ b/include/laik/data.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_DATA_H_
 #define _LAIK_DATA_H_
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 

--- a/include/laik/debug.h
+++ b/include/laik/debug.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_DEBUG_H_
 #define _LAIK_DEBUG_H_
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 

--- a/include/laik/definitions.h
+++ b/include/laik/definitions.h
@@ -18,6 +18,10 @@
 #ifndef _LAIK_DEFINITIONS_H_
 #define _LAIK_DEFINITIONS_H_
 
+#ifndef _LAIK_INTERNAL_H_INSIDE_
+#error "include laik-internal.h instead"
+#endif
+
 #define MAX_GROUPS        10
 #define MAX_SPACES        10
 #define MAX_PARTITIONINGS 10

--- a/include/laik/ext.h
+++ b/include/laik/ext.h
@@ -19,6 +19,10 @@
 #ifndef _LAIK_EXT_H_
 #define _LAIK_EXT_H_
 
+#ifndef _LAIK_H_INSIDE_
+#error "include laik.h instead"
+#endif
+
 #include <laik/agent.h>
 
 // "laik.h" includes the following. This is just to make IDE happy

--- a/include/laik/profiling-internal.h
+++ b/include/laik/profiling-internal.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_PROFILING_INTERNAL_
 #define _LAIK_PROFILING_INTERNAL_
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/profiling.h
+++ b/include/laik/profiling.h
@@ -19,7 +19,7 @@
 #ifndef _LAIK_PROFILING_H_
 #define _LAIK_PROFILING_H_
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 

--- a/include/laik/program-internal.h
+++ b/include/laik/program-internal.h
@@ -18,7 +18,7 @@
 #ifndef LAIK_PROGRAM_INTERNAL
 #define LAIK_PROGRAM_INTERNAL
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/program.h
+++ b/include/laik/program.h
@@ -19,7 +19,7 @@
 #ifndef LAIK_PROGRAM_H
 #define LAIK_PROGRAM_H
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 

--- a/include/laik/space-internal.h
+++ b/include/laik/space-internal.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_SPACE_INTERNAL_H_
 #define _LAIK_SPACE_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
+#ifndef _LAIK_INTERNAL_H_INSIDE_
 #error "include laik-internal.h instead"
 #endif
 

--- a/include/laik/space.h
+++ b/include/laik/space.h
@@ -18,7 +18,7 @@
 #ifndef _LAIK_SPACE_H_
 #define _LAIK_SPACE_H_
 
-#ifndef _LAIK_H_
+#ifndef _LAIK_H_INSIDE_
 #error "include laik.h instead"
 #endif
 


### PR DESCRIPTION
… them.

Previously, including "laik.h" and then e.g. "laik/core.h" would
work. With the change, this will now correctly trigger an error.