### PR TITLE
include: Make every file self-contained and remove the #error messages.

### DIFF
--- a/include/laik-internal.h
+++ b/include/laik-internal.h
@@ -29,6 +29,5 @@
 #include "laik/backend.h"
 #include "laik/program-internal.h"
 #include "laik/profiling-internal.h"
-#include "laik/ext.h"
 
 #endif // _LAIK_INTERNAL_H_

--- a/include/laik/backend.h
+++ b/include/laik/backend.h
@@ -24,16 +24,8 @@
 // Do not include this file in LAIK applications!
 //
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
-// "laik-internal.h" includes all the following. This is just to make IDE happy
-#include "core.h"
-#include "space.h"
-#include "space-internal.h"
-#include "data-internal.h"
-#include <stdbool.h>
+#include <laik.h>     // for Laik_Transition, Laik_Data, Laik_Instance, Laik...
+#include <stdbool.h>  // for bool
 
 // specific to backend driver, result of preparing the execution of a transition
 typedef struct _Laik_TransitionPlan Laik_TransitionPlan;

--- a/include/laik/core-internal.h
+++ b/include/laik/core-internal.h
@@ -18,14 +18,9 @@
 #ifndef _LAIK_CORE_INTERNAL_H_
 #define _LAIK_CORE_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
-#include "ext.h"
-#include "laik-internal.h"
-#include "definitions.h"
-
+#include <laik.h>         // for Laik_Instance, Laik_Group, Laik_AccessPhase
+#include <stdbool.h>      // for bool
+#include "definitions.h"  // for MAX_DATAS, MAX_GROUPS, MAX_MAPPINGS
 
 // key-value store (see below)
 typedef struct _Laik_KVNode Laik_KVNode;

--- a/include/laik/core.h
+++ b/include/laik/core.h
@@ -18,11 +18,7 @@
 #ifndef _LAIK_CORE_H_
 #define _LAIK_CORE_H_
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-#include <stdbool.h>
+#include <stdbool.h>  // for bool
 
 // configuration for a LAIK instance (there may be multiple)
 typedef struct _Laik_Instance Laik_Instance;

--- a/include/laik/data-internal.h
+++ b/include/laik/data-internal.h
@@ -18,15 +18,9 @@
 #ifndef _LAIK_DATA_INTERNAL_H_
 #define _LAIK_DATA_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
-// already included - this is just for an IDE to know about LAIK types
-#include "laik-internal.h"
-
-#include <stdbool.h>
-#include <stdint.h>
+#include <laik.h>     // for Laik_Mapping, Laik_Slice, Laik_Data, Laik_Switc...
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for uint64_t
 
 // kinds of data types supported by Laik
 typedef enum _Laik_TypeKind {

--- a/include/laik/data.h
+++ b/include/laik/data.h
@@ -18,18 +18,11 @@
 #ifndef _LAIK_DATA_H_
 #define _LAIK_DATA_H_
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
-#include "space.h"
-
-#include <stdbool.h>
-#include <stdint.h>  // uint64_t
-#include <stdlib.h>  // size_t
-
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for int64_t, uint64_t
+#include <stdlib.h>   // for size_t
+#include "core.h"     // for Laik_Group, Laik_Instance
+#include "space.h"    // for Laik_DataFlow, Laik_AccessPhase, Laik_Partitioning
 
 /*********************************************************************/
 /* LAIK Data - Data containers for LAIK index spaces

--- a/include/laik/debug.h
+++ b/include/laik/debug.h
@@ -18,16 +18,9 @@
 #ifndef _LAIK_DEBUG_H_
 #define _LAIK_DEBUG_H_
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
-#include "space.h"
-#include "data.h"
-
-#include <stdint.h>
+#include <stdint.h>  // for uint64_t
+#include "data.h"    // for Laik_SwitchStat
+#include "space.h"   // for Laik_DataFlow, Laik_Index, Laik_Partitioning
 
 void laik_log_IntList(int len, int* list);
 void laik_log_PrettyInt(uint64_t v);

--- a/include/laik/ext.h
+++ b/include/laik/ext.h
@@ -19,10 +19,8 @@
 #ifndef _LAIK_EXT_H_
 #define _LAIK_EXT_H_
 
-#include <laik/agent.h>
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
+#include "agent.h"  // for Laik_Agent, laik_agent_init
+#include "core.h"   // for Laik_Instance
 
 // LAIK application-external interfaces
 //

--- a/include/laik/profiling-internal.h
+++ b/include/laik/profiling-internal.h
@@ -18,13 +18,8 @@
 #ifndef _LAIK_PROFILING_INTERNAL_
 #define _LAIK_PROFILING_INTERNAL_
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
-#include "definitions.h"
-
-#include <stdbool.h>
+#include <stdbool.h>      // for bool
+#include "definitions.h"  // for MAX_FILENAME_LENGTH
 
 struct _Laik_Profiling_Controller
 {

--- a/include/laik/profiling.h
+++ b/include/laik/profiling.h
@@ -19,12 +19,7 @@
 #ifndef _LAIK_PROFILING_H_
 #define _LAIK_PROFILING_H_
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
+#include "core.h"  // for Laik_Instance
 
 //
 // application controlled profiling

--- a/include/laik/program-internal.h
+++ b/include/laik/program-internal.h
@@ -18,10 +18,6 @@
 #ifndef LAIK_PROGRAM_INTERNAL
 #define LAIK_PROGRAM_INTERNAL
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
 struct tag_laik_program_control
 {
     int cur_phase;

--- a/include/laik/program.h
+++ b/include/laik/program.h
@@ -19,12 +19,7 @@
 #ifndef LAIK_PROGRAM_H
 #define LAIK_PROGRAM_H
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
+#include "core.h"  // for Laik_Instance
 
 // struct for storing program control information
 typedef struct tag_laik_program_control Laik_Program_Control;

--- a/include/laik/space-internal.h
+++ b/include/laik/space-internal.h
@@ -18,15 +18,9 @@
 #ifndef _LAIK_SPACE_INTERNAL_H_
 #define _LAIK_SPACE_INTERNAL_H_
 
-#ifndef _LAIK_INTERNAL_H_
-#error "include laik-internal.h instead"
-#endif
-
-#include <stdbool.h>
-#include <stdint.h>
-
-// "laik-internal.h" includes the following. This is just to make IDE happy
-#include "space.h"
+#include <laik.h>     // for Laik_AccessPhase, Laik_Index, Laik_Partitioning
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for int64_t
 
 void laik_set_index(Laik_Index* i, int64_t i1, int64_t i2, int64_t i3);
 void laik_add_index(Laik_Index* res, Laik_Index* src1, Laik_Index* src2);

--- a/include/laik/space.h
+++ b/include/laik/space.h
@@ -18,15 +18,9 @@
 #ifndef _LAIK_SPACE_H_
 #define _LAIK_SPACE_H_
 
-#ifndef _LAIK_H_
-#error "include laik.h instead"
-#endif
-
-// "laik.h" includes the following. This is just to make IDE happy
-#include "core.h"
-
-#include <stdint.h>
-#include <stdbool.h>
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for int64_t, uint64_t
+#include "core.h"     // for Laik_Group, Laik_Instance
 
 /*********************************************************************/
 /* LAIK Spaces - Distributed partitioning of index spaces


### PR DESCRIPTION
Every file is now compilable as a standalone unit as verified by this command:

```
find 'include' -name '*.h' -type f -exec cc -fsyntax-only -I 'include' {} \;
```