### PR TITLE
Dockerfile: Add the dependencies for the TCP backend.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     "bear" \
     "clang" \
     "clang-tidy" \
+    "libglib2.0-dev" \
     "libmosquitto-dev" \
     "libopenmpi-dev" \
     "libpapi-dev" \


### PR DESCRIPTION
In case both #58 and #116 are merged, this will be needed to un-break the Travis build. Otherwise this can (and should) simply be closed!