### PR TITLE
tests/tcp/CMakeLists.txt: Switch to the new preprocessor flag for the TCP backend.

### DIFF
--- a/tests/tcp/CMakeLists.txt
+++ b/tests/tcp/CMakeLists.txt
@@ -1,6 +1,6 @@
 get_target_property (definitions "laik" "COMPILE_DEFINITIONS")
 
-if ("LAIK_TCP_BACKEND_AVAILABLE" IN_LIST definitions)
+if ("USE_TCP" IN_LIST definitions)
     foreach (test
         "jac1d_1000_50_10.sh"
         "jac1d_100.sh"


### PR DESCRIPTION
This was missed in commit 58d3cf8ded1abaf57816a8f8b7a9cb2ae85531f3.