### PR TITLE
 Dockerfile: Stop installing the "openmpi-bin" package manually.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     "libpapi-dev" \
     "libprotobuf-c-dev" \
     "make" \
-    "openmpi-bin" \
     "openssh-client" \
     "pkg-config" \
     "protobuf-c-compiler" \


### PR DESCRIPTION
Both Debian and Ubuntu's ```libopenmpi-dev``` package already pull in
```openmpi-bin``` on standard installation (```libopenmpi-dev``` depends on
```libopenmpi``` which recommends ```openmpi-bin``` [0-3]), so installing this
 manually is unnecessary.

Furthermore, this means there's now only a single mention of OpenMPI in the
Dockerfile which should make adding a MPICH test much easier.

[0] https://packages.debian.org/stretch/libopenmpi-dev
[1] https://packages.debian.org/stretch/libopenmpi2
[2] https://packages.ubuntu.com/xenial/libopenmpi-dev
[3] https://packages.ubuntu.com/xenial/libopenmpi1.10