### PR TITLE
tests/mpi: Use "mpiexec -n 4" instead of "mpirun -np 4" everywhere.

### DIFF
--- a/tests/mpi/test-jac1d-100-mpi-1.sh
+++ b/tests/mpi/test-jac1d-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac1d 100 > test-jac1d-100-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/jac1d 100 > test-jac1d-100-mpi-1.out
 cmp test-jac1d-100-mpi-1.out "$(dirname -- "${0}")/../test-jac1d-100.expected"

--- a/tests/mpi/test-jac1d-100-mpi-4.sh
+++ b/tests/mpi/test-jac1d-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac1d 100 > test-jac1d-100-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac1d 100 > test-jac1d-100-mpi-4.out
 cmp test-jac1d-100-mpi-4.out "$(dirname -- "${0}")/test-jac1d-100.expected"

--- a/tests/mpi/test-jac1d-1000-repart-mpi-1.sh
+++ b/tests/mpi/test-jac1d-1000-repart-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-1.out
 cmp test-jac1d-1000-repart-mpi-1.out "$(dirname -- "${0}")/../test-jac1d-1000-repart.expected"

--- a/tests/mpi/test-jac1d-1000-repart-mpi-4.sh
+++ b/tests/mpi/test-jac1d-1000-repart-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-4.out
 cmp test-jac1d-1000-repart-mpi-4.out "$(dirname -- "${0}")/test-jac1d-1000-repart.expected"

--- a/tests/mpi/test-jac2d-1000-mpi-1.sh
+++ b/tests/mpi/test-jac2d-1000-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-1.out
 cmp test-jac2d-1000-mpi-1.out "$(dirname -- "${0}")/../test-jac2d-1000.expected"

--- a/tests/mpi/test-jac2d-1000-mpi-4.sh
+++ b/tests/mpi/test-jac2d-1000-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-4.out
 cmp test-jac2d-1000-mpi-4.out "$(dirname -- "${0}")/test-jac2d-1000.expected"

--- a/tests/mpi/test-jac2dn-1000-mpi-4.sh
+++ b/tests/mpi/test-jac2dn-1000-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test with no-corners halo partitioner
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac2d -s -n 1000 > test-jac2dn-1000-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac2d -s -n 1000 > test-jac2dn-1000-mpi-4.out
 cmp test-jac2dn-1000-mpi-4.out "$(dirname -- "${0}")/test-jac2dn-1000.expected"

--- a/tests/mpi/test-jac3d-100-mpi-1.sh
+++ b/tests/mpi/test-jac3d-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-1.out
 cmp test-jac3d-100-mpi-1.out "$(dirname -- "${0}")/../test-jac3d-100.expected"

--- a/tests/mpi/test-jac3d-100-mpi-4.sh
+++ b/tests/mpi/test-jac3d-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-4.out
 cmp test-jac3d-100-mpi-4.out "$(dirname -- "${0}")/test-jac3d-100.expected"

--- a/tests/mpi/test-jac3dn-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dn-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -s -n 100 > test-jac3dn-100-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac3d -s -n 100 > test-jac3dn-100-mpi-4.out
 cmp test-jac3dn-100-mpi-4.out "$(dirname -- "${0}")/test-jac3dn-100.expected"

--- a/tests/mpi/test-jac3dnr-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dnr-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -n -r -s 100 > test-jac3dnr-100-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac3d -n -r -s 100 > test-jac3dnr-100-mpi-4.out
 cmp test-jac3dnr-100-mpi-4.out "$(dirname -- "${0}")/test-jac3dn-100.expected"

--- a/tests/mpi/test-jac3dr-100-mpi-1.sh
+++ b/tests/mpi/test-jac3dr-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-1.out
 cmp test-jac3dr-100-mpi-1.out "$(dirname -- "${0}")/../test-jac3d-100.expected"

--- a/tests/mpi/test-jac3dr-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dr-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-4.out
 cmp test-jac3dr-100-mpi-4.out "$(dirname -- "${0}")/test-jac3d-100.expected"

--- a/tests/mpi/test-markov-20-4-mpi-1.sh
+++ b/tests/mpi/test-markov-20-4-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/markov 20 4 > test-markov-20-4-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/markov 20 4 > test-markov-20-4-mpi-1.out
 cmp test-markov-20-4-mpi-1.out "$(dirname -- "${0}")/../test-markov-20-4.expected"

--- a/tests/mpi/test-markov-40-4-mpi-4.sh
+++ b/tests/mpi/test-markov-40-4-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/markov 40 4 > test-markov-40-4-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/markov 40 4 > test-markov-40-4-mpi-4.out
 cmp test-markov-40-4-mpi-4.out "$(dirname -- "${0}")/test-markov-40-4.expected"

--- a/tests/mpi/test-markov2-20-4-mpi-1.sh
+++ b/tests/mpi/test-markov2-20-4-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/markov2 20 4 > test-markov2-20-4-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/markov2 20 4 > test-markov2-20-4-mpi-1.out
 cmp test-markov2-20-4-mpi-1.out "$(dirname -- "${0}")/../test-markov2-20-4.expected"

--- a/tests/mpi/test-markov2-40-4-mpi-4.sh
+++ b/tests/mpi/test-markov2-40-4-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/markov2 40 4 > test-markov2-40-4-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/markov2 40 4 > test-markov2-40-4-mpi-4.out
 cmp test-markov2-40-4-mpi-4.out "$(dirname -- "${0}")/test-markov2-40-4.expected"

--- a/tests/mpi/test-propagation2d-10-mpi-1.sh
+++ b/tests/mpi/test-propagation2d-10-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-1.out
 cmp test-propagation2d-10-mpi-1.out "$(dirname -- "${0}")/../test-propagation2d-10.expected"

--- a/tests/mpi/test-propagation2d-10-mpi-4.sh
+++ b/tests/mpi/test-propagation2d-10-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-4.out
 cmp test-propagation2d-10-mpi-4.out "$(dirname -- "${0}")/test-propagation2d-10.expected"

--- a/tests/mpi/test-spmv-mpi-1.sh
+++ b/tests/mpi/test-spmv-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv 4000 > test-spmv-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/spmv 4000 > test-spmv-mpi-1.out
 cmp test-spmv-mpi-1.out "$(dirname -- "${0}")/../test-spmv.expected"

--- a/tests/mpi/test-spmv-mpi-4.sh
+++ b/tests/mpi/test-spmv-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv 4000 | LC_ALL='C' sort > test-spmv-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/spmv 4000 | LC_ALL='C' sort > test-spmv-mpi-4.out
 cmp test-spmv-mpi-4.out "$(dirname -- "${0}")/test-spmv.expected"

--- a/tests/mpi/test-spmv2-mpi-1.sh
+++ b/tests/mpi/test-spmv2-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv2 10 3000 > test-spmv2-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/spmv2 10 3000 > test-spmv2-mpi-1.out
 cmp test-spmv2-mpi-1.out "$(dirname -- "${0}")/../test-spmv2.expected"

--- a/tests/mpi/test-spmv2-mpi-4.sh
+++ b/tests/mpi/test-spmv2-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 10 3000 | LC_ALL='C' sort > test-spmv2-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/spmv2 10 3000 | LC_ALL='C' sort > test-spmv2-mpi-4.out
 cmp test-spmv2-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2-shrink-inc-mpi-4.sh
+++ b/tests/mpi/test-spmv2-shrink-inc-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test shrinking with incremental partitioner
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -s 2 -i 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-inc-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/spmv2 -s 2 -i 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-inc-mpi-4.out
 cmp test-spmv2-shrink-inc-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2-shrink-mpi-4.sh
+++ b/tests/mpi/test-spmv2-shrink-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test shrinking in spmv2
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -s 2 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/spmv2 -s 2 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-mpi-4.out
 cmp test-spmv2-shrink-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2r-mpi-1.sh
+++ b/tests/mpi/test-spmv2r-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv2 -r 10 3000 > test-spmv2r-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/spmv2 -r 10 3000 > test-spmv2r-mpi-1.out
 cmp test-spmv2r-mpi-1.out "$(dirname -- "${0}")/../test-spmv2.expected"

--- a/tests/mpi/test-spmv2r-mpi-4.sh
+++ b/tests/mpi/test-spmv2r-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -r 10 3000 | LC_ALL='C' sort > test-spmv2r-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/spmv2 -r 10 3000 | LC_ALL='C' sort > test-spmv2r-mpi-4.out
 cmp test-spmv2r-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-vsum-mpi-1.sh
+++ b/tests/mpi/test-vsum-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum > test-vsum-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/vsum > test-vsum-mpi-1.out
 cmp test-vsum-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum-mpi-4.sh
+++ b/tests/mpi/test-vsum-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum | LC_ALL='C' sort > test-vsum-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/vsum | LC_ALL='C' sort > test-vsum-mpi-4.out
 cmp test-vsum-mpi-4.out "$(dirname -- "${0}")/test-vsum.expected"

--- a/tests/mpi/test-vsum2-mpi-1.sh
+++ b/tests/mpi/test-vsum2-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum2 > test-vsum2-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/vsum2 > test-vsum2-mpi-1.out
 cmp test-vsum2-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum2-mpi-4.sh
+++ b/tests/mpi/test-vsum2-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum2 | LC_ALL='C' sort > test-vsum2-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/vsum2 | LC_ALL='C' sort > test-vsum2-mpi-4.out
 cmp test-vsum2-mpi-4.out "$(dirname -- "${0}")/test-vsum2.expected"

--- a/tests/mpi/test-vsum3-mpi-1.sh
+++ b/tests/mpi/test-vsum3-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum3 > test-vsum3-mpi-1.out
+LAIK_BACKEND=mpi mpiexec -n 1 ../../examples/vsum3 > test-vsum3-mpi-1.out
 cmp test-vsum3-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum3-mpi-4.sh
+++ b/tests/mpi/test-vsum3-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum3 | LC_ALL='C' sort > test-vsum3-mpi-4.out
+LAIK_BACKEND=mpi mpiexec -n 4 ../../examples/vsum3 | LC_ALL='C' sort > test-vsum3-mpi-4.out
 cmp test-vsum3-mpi-4.out "$(dirname -- "${0}")/test-vsum.expected"


### PR DESCRIPTION
In contrast to ```mpirun -np 4```, ```mpiexec -n 4``` is actually supported by
the MPI standard [0] and works with both OpenMPI and MPICH, so this should get
us one step closer to be able to testing with MPICH.

[0] http://mpi-forum.org/docs/mpi-3.1/mpi31-report/node228.htm#Node228