### PR TITLE
src/backends/tcp: Use Glib's endian conversion macros.

### DIFF
--- a/src/backends/tcp/minimpi.c
+++ b/src/backends/tcp/minimpi.c
@@ -1,5 +1,4 @@
 #include "minimpi.h"
-#include <endian.h>     // for htole64, htobe64
 #include <glib.h>       // for g_autoptr, g_bytes_get_size, GBytes_autoptr
 #include <stdbool.h>    // for false
 #include <stdint.h>     // for uint64_t, int64_t, SIZE_MAX
@@ -72,12 +71,12 @@ static GBytes* laik_tcp_minimpi_header (uint64_t generation, uint64_t type, uint
     laik_tcp_always (flows);
 
     const uint64_t data[] = {
-        htole64 (generation),
-        htole64 (type),
-        htole64 (sender),
-        htole64 (receiver),
-        htole64 (tag),
-        htole64 (0),
+        GUINT64_TO_LE (generation),
+        GUINT64_TO_LE (type),
+        GUINT64_TO_LE (sender),
+        GUINT64_TO_LE (receiver),
+        GUINT64_TO_LE (tag),
+        GUINT64_TO_LE (0),
     };
 
     GBytes* result = g_bytes_new (&data, sizeof (data));
@@ -85,7 +84,7 @@ static GBytes* laik_tcp_minimpi_header (uint64_t generation, uint64_t type, uint
     uint64_t* serial = g_hash_table_lookup (flows, result);
 
     if (serial) {
-        ((uint64_t*) g_bytes_get_data (result, NULL))[5] = htobe64 (++*serial);
+        ((uint64_t*) g_bytes_get_data (result, NULL))[5] = GUINT64_TO_LE (++*serial);
     } else {
         g_hash_table_insert (flows, g_bytes_ref (result), g_new0 (uint64_t, 1));
     }

--- a/src/backends/tcp/socket.c
+++ b/src/backends/tcp/socket.c
@@ -1,5 +1,4 @@
 #include "socket.h"
-#include <endian.h>       // for htole64, le64toh
 #include <errno.h>        // for errno
 #include <glib.h>         // for g_malloc0_n, GPtrArray, g_autofree, g_new0
 #include <netdb.h>        // for getaddrinfo
@@ -14,7 +13,7 @@
 #include <sys/un.h>       // for sockaddr_un, sa_family_t
 #include <unistd.h>       // for close, ssize_t
 #include "addressinfo.h"  // for Laik_Tcp_AddressInfo, Laik_Tcp_AddressInfo_...
-#include "config.h"       // for laik_tcp_config, Laik_Tcp_Config_autoptr
+#include "config.h"       // for Laik_Tcp_Config, laik_tcp_config, Laik_Tcp_...
 #include "debug.h"        // for laik_tcp_always, laik_tcp_debug
 #include "errors.h"       // for laik_tcp_errors_push, Laik_Tcp_Errors
 #include "time.h"         // for laik_tcp_time
@@ -322,7 +321,7 @@ bool laik_tcp_socket_receive_uint64 (Laik_Tcp_Socket* this, uint64_t* value) {
         return false;
     }
 
-    *value = le64toh (*value);
+    *value = GUINT64_FROM_LE (*value);
 
     return true;
 }
@@ -348,7 +347,7 @@ bool laik_tcp_socket_send_bytes (Laik_Tcp_Socket* this, GBytes* bytes) {
 bool laik_tcp_socket_send_uint64 (Laik_Tcp_Socket* this, uint64_t value) {
     laik_tcp_always (this);
 
-    value = htole64 (value);
+    value = GUINT64_TO_LE (value);
 
     return laik_tcp_socket_send_raw (this, &value, sizeof (value));
 }

--- a/tools/iwyu/map.yaml
+++ b/tools/iwyu/map.yaml
@@ -1,7 +1,7 @@
 # IWYU mapping file for LAIK, see [0] for details on the format!
 # [0] https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUMappings.md
 
-# IWYU somehow doesn't get these two right...
+# IWYU somehow doesn't get these includes right automatically, so fix them here
 - include:
   - '<bits/stdint-intn.h>'
   - 'private'
@@ -12,6 +12,12 @@
   - '<bits/stdint-uintn.h>'
   - 'private'
   - '<stdint.h>'
+  - 'public'
+
+- include:
+  - '<glib/gtypes.h>'
+  - 'private'
+  - '<glib.h>'
   - 'public'
 
 # Accessing the public API is only allowed via "#include <laik.h>"


### PR DESCRIPTION
Closes #131.