### PR TITLE
tools/iwyu/map.yaml: Be more cautious when using the ".*" regex.

### DIFF
--- a/tools/iwyu/map.yaml
+++ b/tools/iwyu/map.yaml
@@ -22,7 +22,7 @@
   - 'public'
 
 - include:
-  - '@.laik/(action|core|data|debug|ext|profiling|program|space).*'
+  - '@.laik/(action|core|data|debug|ext|profiling|program|space)\.h.'
   - 'private'
   - '<laik.h>'
   - 'public'
@@ -35,7 +35,7 @@
   - 'public'
 
 - include:
-  - '@.laik/(agent|backend|definitions|.*-internal).*'
+  - '@.laik/(agent|backend|definitions|.*-internal)\.h.'
   - 'private'
   - '<laik-internal.h>'
   - 'public'


### PR DESCRIPTION
Before this, IWYU would match e.g. "<laik/space-internal.h>" to
laik.h's regex which is clearly incorrect.