### PR TITLE
CMakeLists.txt: Use "-pedantic" instead of "-Wpedantic" to avoid a ICC warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ enable_testing ()
 
 # Set some global defaults
 add_compile_options (
+    "-pedantic"
     "-Wall"
     "-Werror"
     "-Wextra"
-    "-Wpedantic"
 )
 set (CMAKE_C_STANDARD            11)
 set (CMAKE_C_EXTENSIONS          ON)


### PR DESCRIPTION
ICC doesn't know the "-Wpedantic" option, and for both GCC and Clang "-pedantic"
and "-Wpedantic" mean the same thing, so simply switch the option here to avoid
a warning with ICC.