### PR TITLE
src/core.c: Cast the log level to the correct type before storing it.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -154,7 +154,7 @@ Laik_Instance* laik_new_instance(const Laik_Backend* b,
     if (str) {
         int l = atoi(str);
         if (l > 0)
-            laik_loglevel = l;
+            laik_loglevel = (Laik_LogLevel) l;
         char* p = index(str, ':');
         if (p) {
             p++;


### PR DESCRIPTION
This fixes a warning emitted by ICC about incompatible enums (ICC warning #188).