### PR TITLE
Use Coccinelle to fix the remaining ICC enum warnings

### DIFF
--- a/examples/jac1d.c
+++ b/examples/jac1d.c
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
         assert(off == countW - 1);
         baseW[off] = hiValue;
     }
-    laik_log(2, "Init done\n");
+    laik_log(LAIK_LL_Info, "Init done\n");
 
     // for statistics (with LAIK_LOG=2)
     double t, t1 = laik_wtime(), t2 = t1;
@@ -168,7 +168,8 @@ int main(int argc, char* argv[])
             res_iters++;
 
             // calculate global residuum
-            laik_switchto_flow(sumD, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+            laik_switchto_flow(sumD,
+                               (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
             laik_map_def1(sumD, (void**) &sumPtr, 0);
             *sumPtr = res;
             laik_switchto_flow(sumD, LAIK_DF_CopyIn);
@@ -181,10 +182,10 @@ int main(int argc, char* argv[])
                 int diter = (iter + 1) - last_iter;
                 double dt = t - t2;
                 double gUpdates = 0.000000001 * size; // per iteration
-                laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
-                         diter, dt,
+                laik_log(LAIK_LL_Info,
+                         "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s", diter,
                          // 2 Flops per update in reg iters, with res 5 (once)
-                         gUpdates * (5 + 2 * (diter-1)) / dt,
+                         dt, gUpdates * (5 + 2 * (diter - 1)) / dt,
                          // per update 16 bytes read + 8 byte written
                          gUpdates * diter * 24 / dt);
                 last_iter = iter + 1;
@@ -229,7 +230,8 @@ int main(int argc, char* argv[])
     for(uint64_t i = 0; i < countW; i++) sum += baseW[i];
 
     // global reduction of local sum values
-    laik_switchto_flow(sumD, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+    laik_switchto_flow(sumD,
+                       (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     laik_map_def1(sumD, (void**) &sumPtr, 0);
     *sumPtr = sum;
     laik_switchto_flow(sumD, LAIK_DF_CopyIn);
@@ -238,12 +240,12 @@ int main(int argc, char* argv[])
 
     // statistics for all iterations and reductions
     // using work load in all tasks
-    if (laik_logshown(2)) {
+    if (laik_logshown(LAIK_LL_Info)) {
         t = laik_wtime();
         int diter = iter;
         double dt = t - t1;
         double gUpdates = 0.000000001 * size; // per iteration
-        laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
+        laik_log(LAIK_LL_Info, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
                  diter, dt,
                  // 2 Flops per update in reg iters, with res 5
                  gUpdates * (5 * res_iters + 2 * (diter - res_iters)) / dt,

--- a/examples/jac2d.c
+++ b/examples/jac2d.c
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
         for(uint64_t y = 0; y < ysizeW; y++)
             baseW[y * ystrideW + xsizeW - 1] = hiColValue;
     }
-    laik_log(2, "Init done\n");
+    laik_log(LAIK_LL_Info, "Init done\n");
 
     // for statistics (with LAIK_LOG=2)
     double t, t1 = laik_wtime(), t2 = t1;
@@ -233,7 +233,8 @@ int main(int argc, char* argv[])
             res_iters++;
 
             // calculate global residuum
-            laik_switchto_flow(sumD, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+            laik_switchto_flow(sumD,
+                               (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
             laik_map_def1(sumD, (void**) &sumPtr, 0);
             *sumPtr = res;
             laik_switchto_flow(sumD, LAIK_DF_CopyIn);
@@ -246,10 +247,10 @@ int main(int argc, char* argv[])
                 int diter = (iter + 1) - last_iter;
                 double dt = t - t2;
                 double gUpdates = 0.000000001 * size * size; // per iteration
-                laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
-                         diter, dt,
+                laik_log(LAIK_LL_Info,
+                         "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s", diter,
                          // 4 Flops per update in reg iters, with res 7 (once)
-                         gUpdates * (7 + 4 * (diter-1)) / dt,
+                         dt, gUpdates * (7 + 4 * (diter - 1)) / dt,
                          // per update 32 bytes read + 8 byte written
                          gUpdates * diter * 40 / dt);
                 last_iter = iter + 1;
@@ -280,12 +281,12 @@ int main(int argc, char* argv[])
 
     // statistics for all iterations and reductions
     // using work load in all tasks
-    if (laik_logshown(2)) {
+    if (laik_logshown(LAIK_LL_Info)) {
         t = laik_wtime();
         int diter = iter;
         double dt = t - t1;
         double gUpdates = 0.000000001 * size * size; // per iteration
-        laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
+        laik_log(LAIK_LL_Info, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
                  diter, dt,
                  // 2 Flops per update in reg iters, with res 5
                  gUpdates * (7 * res_iters + 4 * (diter - res_iters)) / dt,

--- a/examples/jac3d-ll.c
+++ b/examples/jac3d-ll.c
@@ -239,7 +239,7 @@ int main(int argc, char* argv[])
                         (double) ((gx1 + x + gy1 + y + gz1 + z) & 6);
 
     setBoundary(size, paWrite, dWrite);
-    laik_log(2, "Init done\n");
+    laik_log(LAIK_LL_Info, "Init done\n");
 
     // set data2 to read to make exec_transtion happy (this is a no-op)
     laik_switchto_partitioning(dRead,  paRead,  LAIK_DF_CopyIn);
@@ -348,7 +348,8 @@ int main(int argc, char* argv[])
             res_iters++;
 
             // calculate global residuum
-            laik_switchto_flow(sumD, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+            laik_switchto_flow(sumD,
+                               (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
             laik_map_def1(sumD, (void**) &sumPtr, 0);
             *sumPtr = res;
             laik_switchto_flow(sumD, LAIK_DF_CopyIn);
@@ -361,10 +362,10 @@ int main(int argc, char* argv[])
                 int diter = (iter + 1) - last_iter;
                 double dt = t - t2;
                 double gUpdates = 0.000000001 * size * size * size; // per iteration
-                laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
-                         diter, dt,
+                laik_log(LAIK_LL_Info,
+                         "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s", diter,
                          // 6 Flops per update in reg iters, with res 9 (once)
-                         gUpdates * (9 + 6 * (diter-1)) / dt,
+                         dt, gUpdates * (9 + 6 * (diter - 1)) / dt,
                          // per update 48 bytes read + 8 byte written
                          gUpdates * diter * 56 / dt);
                 last_iter = iter + 1;
@@ -402,12 +403,12 @@ int main(int argc, char* argv[])
 
     // statistics for all iterations and reductions
     // using work load in all tasks
-    if (laik_logshown(2)) {
+    if (laik_logshown(LAIK_LL_Info)) {
         t = laik_wtime();
         int diter = iter;
         double dt = t - t1;
         double gUpdates = 0.000000001 * size * size * size; // per iteration
-        laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
+        laik_log(LAIK_LL_Info, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
                  diter, dt,
                  // 6 Flops per update in reg iters, with res 4
                  gUpdates * (9 * res_iters + 6 * (diter - res_iters)) / dt,

--- a/examples/jac3d.c
+++ b/examples/jac3d.c
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
                         (double) ((gx1 + x + gy1 + y + gz1 + z) & 6);
 
     setBoundary(size, pWrite, dWrite);
-    laik_log(2, "Init done\n");
+    laik_log(LAIK_LL_Info, "Init done\n");
 
     // for statistics (with LAIK_LOG=2)
     double t, t1 = laik_wtime(), t2 = t1;
@@ -286,7 +286,8 @@ int main(int argc, char* argv[])
             res_iters++;
 
             // calculate global residuum
-            laik_switchto_flow(sumD, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+            laik_switchto_flow(sumD,
+                               (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
             laik_map_def1(sumD, (void**) &sumPtr, 0);
             *sumPtr = res;
             laik_switchto_flow(sumD, LAIK_DF_CopyIn);
@@ -299,11 +300,11 @@ int main(int argc, char* argv[])
                 int diter = (iter + 1) - last_iter;
                 double dt = t - t2;
                 double gUpdates = 0.000000001 * size * size * size; // per iteration
-                laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
-                         diter, dt,
+                laik_log(LAIK_LL_Info,
+                         "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s", diter,
                          // 6 Flops per update in reg iters, with res 9 (once)
-                         gUpdates * (9 + 6 * (diter-1)) / dt,
-                         // per update 48 bytes read + 8 byte written
+                         dt, gUpdates * (9 + 6 * (diter - 1)) / dt,
+                         // // per update 48 bytes read + 8 byte written
                          gUpdates * diter * 56 / dt);
                 last_iter = iter + 1;
                 t2 = t;
@@ -340,12 +341,12 @@ int main(int argc, char* argv[])
 
     // statistics for all iterations and reductions
     // using work load in all tasks
-    if (laik_logshown(2)) {
+    if (laik_logshown(LAIK_LL_Info)) {
         t = laik_wtime();
         int diter = iter;
         double dt = t - t1;
         double gUpdates = 0.000000001 * size * size * size; // per iteration
-        laik_log(2, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
+        laik_log(LAIK_LL_Info, "For %d iters: %.3fs, %.3f GF/s, %.3f GB/s",
                  diter, dt,
                  // 6 Flops per update in reg iters, with res 4
                  gUpdates * (9 * res_iters + 6 * (diter - res_iters)) / dt,

--- a/examples/markov.c
+++ b/examples/markov.c
@@ -303,9 +303,7 @@ int main(int argc, char* argv[])
     pWrite = laik_new_accessphase(world, space,
                                    laik_new_block_partitioner1(), 0);
     pr = laik_new_partitioner("markovin", run_markovPartitioner, &mg,
-                              LAIK_PF_Merge |
-                              (useSingleIndex ? LAIK_PF_SingleIndex : 0) |
-                              (doCompact ? LAIK_PF_Compact : 0));
+                              (Laik_PartitionerFlag)((int)LAIK_PF_Merge | (useSingleIndex ? LAIK_PF_SingleIndex : 0) | (doCompact ? LAIK_PF_Compact : 0)));
     pRead = laik_new_accessphase(world, space, pr, pWrite);
     pMaster = laik_new_accessphase(world, space, laik_Master, 0);
 
@@ -318,7 +316,7 @@ int main(int argc, char* argv[])
         // register initialization function for global-to-local index data
         // this is called whenever the partitioning is changing
         // FIXME: add API to specify function for init
-        laik_switchto_phase(idata, pWrite, 0);
+        laik_switchto_phase(idata, pWrite, LAIK_DF_None);
         // TODO: move to inititialization function
         int* iarray;
         uint64_t icount, ioff;

--- a/examples/propagation2d.c
+++ b/examples/propagation2d.c
@@ -157,9 +157,9 @@ void print_data(Laik_Data* d, Laik_AccessPhase *p)
         laik_map_def(d, s, (void**) &base, &count);
         for (uint64_t i = 0; i < count; i++)
         {
-            laik_log(1,"%f\n", base[i]);
+            laik_log(LAIK_LL_Debug, "%f\n", base[i]);
         }
-        laik_log(1,"\n");
+        laik_log(LAIK_LL_Debug, "\n");
     }
 }
 
@@ -180,7 +180,7 @@ double data_check_sum(Laik_Data* d, Laik_AccessPhase *p, Laik_Group* world)
 
     Laik_Data* laik_sum = laik_new_data_1d(laik_inst(world), laik_Double, 1);
     laik_switchto_new_phase(laik_sum, world, laik_All,
-                            LAIK_DF_ReduceOut | LAIK_DF_Sum);
+                            (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     laik_map_def1(laik_sum, (void**) &base, &count);
     *base=sum;
     laik_switchto_new_phase(laik_sum, world, laik_All,
@@ -312,7 +312,8 @@ int main(int argc, char* argv[])
     laik_switchto_phase(element, pElements, LAIK_DF_CopyIn);
 
     // distribution of the nodes
-    laik_switchto_phase(node, pNodes, LAIK_DF_ReduceOut | LAIK_DF_Sum);
+    laik_switchto_phase(node, pNodes,
+                        (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     //laik_switchto(node, pNodes, LAIK_DF_CopyOut);
     int nSlicesNodes = laik_phase_my_slicecount(pNodes);
     for (int n = 0; n < nSlicesNodes; ++n)
@@ -328,12 +329,12 @@ int main(int argc, char* argv[])
     apply_boundary_condition(node,pNodes,Rx,Ry,rx,ry,0);
 
     // for debug only
-    laik_log(1,"print elements:");
+    laik_log(LAIK_LL_Debug, "print elements:");
     print_data(element, pElements);
-    laik_log(1,"print nodes:");
+    laik_log(LAIK_LL_Debug, "print nodes:");
     print_data(node,pNodes);
 
-    laik_log(1,"Initialization done.\n");
+    laik_log(LAIK_LL_Debug, "Initialization done.\n");
 
     // propagate the values from elements to the nodes
     // perform the propagation maxIt times
@@ -386,7 +387,8 @@ int main(int argc, char* argv[])
         // update the nodes using elements
         // go through all the elements and refere
         // to their neighbouring nodes and update them
-        laik_switchto_phase(node, pNodes, LAIK_DF_Init | LAIK_DF_ReduceOut | LAIK_DF_Sum);
+        laik_switchto_phase(node, pNodes,
+                            (Laik_DataFlow)((int)LAIK_DF_Init | (int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
         for(int m = 0; m < nMapsElements; m++) {
             laik_map_def(element, m, (void **)&baseE, &countE);
 
@@ -425,9 +427,9 @@ int main(int argc, char* argv[])
         apply_boundary_condition(node,pNodes,Rx,Ry,rx,ry,pow(2,it));
     }
     // for debug only
-    laik_log(1,"print elements:");
+    laik_log(LAIK_LL_Debug, "print elements:");
     print_data(element, pElements);
-    laik_log(1,"print nodes:");
+    laik_log(LAIK_LL_Debug, "print nodes:");
     print_data(node,pNodes);
     // print check_sum for test
     double sum;

--- a/examples/spmv.c
+++ b/examples/spmv.c
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
 
     // other way to push results to master: use sum reduction
     laik_switchto_new_phase(resD, world, laik_All,
-                            LAIK_DF_Init | LAIK_DF_ReduceOut | LAIK_DF_Sum);
+                            (Laik_DataFlow)((int)LAIK_DF_Init | (int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     laik_map_def1(resD, (void**) &res, &count);
     laik_phase_myslice_1d(p, 0, &fromRow, &toRow);
     for(int r = fromRow; r < toRow; r++) {

--- a/examples/vsum.c
+++ b/examples/vsum.c
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 
     // distribute data equally among all
     laik_switchto_new_phase(a, world, laik_new_block_partitioner1(),
-                            LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                            (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
     // partial sum using equally-sized blocks
     laik_map_def1(a, (void**) &base, &count);
     for(uint64_t i = 0; i < count; i++) mysum[1] += base[i];
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
 
     // distribution using element-wise weights equal to index
     laik_switchto_new_phase(a, world, laik_new_block_partitioner_iw1(getEW, 0),
-                            LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                            (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
     // partial sum using blocks sized by element weights
     laik_map_def1(a, (void**) &base, &count);
     for(uint64_t i = 0; i < count; i++) mysum[2] += base[i];
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
         Laik_AccessPhase* p;
         p = laik_switchto_new_phase(a, world,
                                     laik_new_block_partitioner_tw1(getTW, 0),
-                                    LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                                    (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
         // partial sum using blocks sized by task weights
         laik_map_def1(a, (void**) &base, &count);
         for(uint64_t i = 0; i < count; i++) mysum[3] += base[i];
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
     // aggregation functionality when switching to new partitioning
     Laik_Data* sum = laik_new_data_1d(inst, laik_Double, 4);
     laik_switchto_new_phase(sum, world, laik_All,
-                            LAIK_DF_ReduceOut | LAIK_DF_Sum);
+                            (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     laik_map_def1(sum, (void**) &base, &count);
     assert(count == 4);
     for(int i = 0; i < 4; i++) base[i] = mysum[i];

--- a/examples/vsum2.c
+++ b/examples/vsum2.c
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
     // distribute data equally among all
     laik_switchto_new_phase(a, world,
                             laik_new_block_partitioner(0, 2, 0, 0, 0),
-                            LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                            (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
     // partial sum using equally-sized blocks, outer loop over slices
     for(int sNo = 0;; sNo++) {
         if (laik_map_def(a, sNo, (void**) &base, &count) == 0) break;
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     // distribution using element-wise weights equal to index
     laik_switchto_new_phase(a, world,
                             laik_new_block_partitioner(0, 2, getEW, 0, 0),
-                            LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                            (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
     // partial sum using blocks sized by element weights
     for(int sNo = 0;; sNo++) {
         if (laik_map_def(a, sNo, (void**) &base, &count) == 0) break;
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
         // distribution using task-wise weights: without master
         laik_switchto_new_phase(a, world,
                                 laik_new_block_partitioner(0, 2, 0, getTW, 0),
-                                LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+                                (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
         // partial sum using blocks sized by task weights
         for(int sNo = 0;; sNo++) {
             if (laik_map_def(a, sNo, (void**) &base, &count) == 0) break;
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
     // aggregation functionality when switching to new partitioning
     Laik_Data* sum = laik_new_data_1d(inst, laik_Double, 4);
     laik_switchto_new_phase(sum, world, laik_All,
-                            LAIK_DF_ReduceOut | LAIK_DF_Sum);
+                            (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
     laik_map_def1(sum, (void**) &base, &count);
     assert(count == 4);
     for(int i = 0; i < 4; i++) base[i] = mysum[i];

--- a/examples/vsum3.c
+++ b/examples/vsum3.c
@@ -78,7 +78,8 @@ int main(int argc, char* argv[])
 
     // distribute data equally among all
     part2 = laik_new_partitioning(laik_new_block_partitioner1(), world, space, 0);
-    laik_switchto_partitioning(array, part2, LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+    laik_switchto_partitioning(array, part2,
+                               (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
 
     // partial sum using equally-sized blocks
     laik_map_def1(array, (void**) &base, &count);
@@ -89,7 +90,8 @@ int main(int argc, char* argv[])
     // distribution using element-wise weights equal to index
     part3 = laik_new_partitioning(laik_new_block_partitioner_iw1(getEW, 0),
                                   world, space, 0);
-    laik_switchto_partitioning(array, part3, LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+    laik_switchto_partitioning(array, part3,
+                               (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
 
     // partial sum using blocks sized by element weights
     laik_map_def1(array, (void**) &base, &count);
@@ -101,7 +103,8 @@ int main(int argc, char* argv[])
         // distribution using task-wise weights: without master
         part4 = laik_new_partitioning(laik_new_block_partitioner_tw1(getTW, 0),
                                       world, space, 0);
-        laik_switchto_partitioning(array, part4, LAIK_DF_CopyIn | LAIK_DF_CopyOut);
+        laik_switchto_partitioning(array, part4,
+                                   (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut));
 
         // partial sum using blocks sized by task weights
         laik_map_def1(array, (void**) &base, &count);
@@ -139,7 +142,7 @@ int main(int argc, char* argv[])
     sumdata  = laik_new_data(sumspace, laik_Double);
     sumpart1 = laik_new_partitioning(laik_All, world, sumspace, 0);
     laik_switchto_partitioning(sumdata, sumpart1,
-                               LAIK_DF_ReduceOut | LAIK_DF_Sum);
+                               (Laik_DataFlow)((int)LAIK_DF_ReduceOut | (int)LAIK_DF_Sum));
 
     laik_map_def1(sumdata, (void**) &base, &count);
     assert(count == 4);

--- a/src/action.c
+++ b/src/action.c
@@ -370,7 +370,7 @@ void laik_actions_optSeq(Laik_ActionSeq* oldAS, Laik_ActionSeq* as)
 
     if (bufSize == 0) {
         assert(copyRanges == 0);
-        laik_log(1, "Optimized action sequence: nothing to do.");
+        laik_log(LAIK_LL_Debug, "Optimized action sequence: nothing to do.");
         laik_actions_copySeq(oldAS, as);
         return;
     }
@@ -379,8 +379,9 @@ void laik_actions_optSeq(Laik_ActionSeq* oldAS, Laik_ActionSeq* as)
     as->buf = malloc(bufSize * elemsize);
     as->ce = malloc(copyRanges * sizeof(Laik_CopyEntry));
 
-    laik_log(1, "Optimized action sequence: buf %p, length %d x %d, ranges %d",
-        (void*) as->buf, bufSize, elemsize, copyRanges);
+    laik_log(LAIK_LL_Debug,
+             "Optimized action sequence: buf %p, length %d x %d, ranges %d",
+             (void *)as->buf, bufSize, elemsize, copyRanges);
 
     // unmark all actions: restart for finding same type of actions
     for(int i = 0; i < oldAS->actionCount; i++)

--- a/src/backend-single.c
+++ b/src/backend-single.c
@@ -31,7 +31,7 @@ Laik_Instance* laik_init_single()
     Laik_Instance* inst;
     inst = laik_new_instance(&laik_backend_single, 1, 0, "local", 0, 0);
 
-    laik_log(1, "Single backend initialized\n");
+    laik_log(LAIK_LL_Debug, "Single backend initialized\n");
 
     single_instance = inst;
     return inst;
@@ -70,10 +70,10 @@ void laik_single_exec(Laik_Data* d, Laik_Transition* t, Laik_ActionSeq* p,
             assert(toBase != 0);
             assert(to > from);
 
-            laik_log(1, "Single reduce: "
-                        "from %lld, to %lld, elemsize %d, base from/to %p/%p\n",
-                     (long long int) from, (long long int) to,
-                     d->elemsize, (void*) fromBase, (void*) toBase);
+            laik_log(LAIK_LL_Debug,
+                     "Single reduce: " "from %lld, to %lld, elemsize %d, base from/to %p/%p\n",
+                     (long long int)from, (long long int)to, d->elemsize,
+                     (void *)fromBase, (void *)toBase);
 
             memcpy(toBase, fromBase, (to-from) * fromMap->data->elemsize);
         }

--- a/src/core.c
+++ b/src/core.c
@@ -82,7 +82,7 @@ int laik_myid(Laik_Group* g)
 
 void laik_finalize(Laik_Instance* inst)
 {
-    laik_log(1, "finalizing...");
+    laik_log(LAIK_LL_Debug, "finalizing...");
     if (inst->backend && inst->backend->finalize)
         (*inst->backend->finalize)(inst);
 
@@ -90,7 +90,7 @@ void laik_finalize(Laik_Instance* inst)
         laik_ext_cleanup(inst);
     }
 
-    if (laik_log_begin(2)) {
+    if (laik_log_begin(LAIK_LL_Info)) {
         laik_log_append("switch statistics (this task):\n");
         for(int i=0; i<inst->data_count; i++) {
             Laik_Data* d = inst->data[i];
@@ -335,7 +335,7 @@ Laik_Group* laik_new_shrinked_group(Laik_Group* g, int len, int* list)
     if (g->inst->backend->updateGroup)
         (g->inst->backend->updateGroup)(g2);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("shrink group: "
                         "%d (size %d, myid %d) => %d (size %d, myid %d):",
                         g->gid, g->size, g->myid, g2->gid, g2->size, g2->myid);

--- a/src/data.c
+++ b/src/data.c
@@ -100,10 +100,10 @@ Laik_Data* laik_new_data(Laik_Space* space, Laik_Type* type)
 
     d->activeReservation = 0;
 
-    laik_log(1, "new data '%s':\n"
-             " type '%s' (elemsize %d), space '%s' (%lu elems, %.3f MB)\n",
+    laik_log(LAIK_LL_Debug,
+             "new data '%s':\n" " type '%s' (elemsize %d), space '%s' (%lu elems, %.3f MB)\n",
              d->name, type->name, d->elemsize, space->name,
-             (unsigned long) laik_space_size(space),
+             (unsigned long)laik_space_size(space),
              0.000001 * laik_space_size(space) * d->elemsize);
 
     laik_addDataForInstance(space->inst, d);
@@ -127,7 +127,7 @@ Laik_Data* laik_new_data_2d(Laik_Instance* i, Laik_Type* t,
 // set a data name, for debug output
 void laik_data_set_name(Laik_Data* d, char* n)
 {
-    laik_log(1, "data '%s' renamed to '%s'", d->name, n);
+    laik_log(LAIK_LL_Debug, "data '%s' renamed to '%s'", d->name, n);
 
     d->name = n;
 }
@@ -230,8 +230,9 @@ Laik_MappingList* prepareMaps(Laik_Data* d, Laik_Partitioning* p,
     ml->res = 0; // not part of a reservation
     ml->count = n;
 
-    laik_log(1, "prepare %d maps for data '%s' (partitioning '%s')",
-             n, d->name, p->name);
+    laik_log(LAIK_LL_Debug,
+             "prepare %d maps for data '%s' (partitioning '%s')", n, d->name,
+             p->name);
 
     if (n == 0) return ml;
 
@@ -259,7 +260,7 @@ Laik_MappingList* prepareMaps(Laik_Data* d, Laik_Partitioning* p,
         m->size[1] = (dims > 1) ? (slc.to.i[1] - slc.from.i[1]) : 0;
         m->size[2] = (dims > 2) ? (slc.to.i[2] - slc.from.i[2]) : 0;
 
-        if (laik_log_begin(1)) {
+        if (laik_log_begin(LAIK_LL_Debug)) {
             laik_log_append("prepare map for '%s'/%d: req.slice ",
                             d->name, mapNo);
             laik_log_Slice(dims, &slc);
@@ -278,9 +279,10 @@ void freeMap(Laik_Mapping* m, Laik_Data* d, Laik_SwitchStat* ss)
     assert(d == m->data);
 
     if (m->reusedFor == -1) {
-        laik_log(1, "free map for '%s'/%d (capacity %llu, base %p, start %p)\n",
-                 d->name, m->mapNo,
-                 (unsigned long long) m->capacity, (void*) m->base, (void*) m->start);
+        laik_log(LAIK_LL_Debug,
+                 "free map for '%s'/%d (capacity %llu, base %p, start %p)\n",
+                 d->name, m->mapNo, (unsigned long long)m->capacity,
+                 (void *)m->base, (void *)m->start);
 
         // concrete, fixed layouts are only used once: free
         if (m->layout && m->layout->isFixed) {
@@ -303,7 +305,8 @@ void freeMap(Laik_Mapping* m, Laik_Data* d, Laik_SwitchStat* ss)
         m->start = 0;
     }
     else
-        laik_log(1, "free map for '%s'/%d: nothing to do (reused for %d)\n",
+        laik_log(LAIK_LL_Debug,
+                 "free map for '%s'/%d: nothing to do (reused for %d)\n",
                  d->name, m->mapNo, m->reusedFor);
 }
 
@@ -431,14 +434,13 @@ void laik_allocateMap(Laik_Mapping* m, Laik_SwitchStat* ss)
     default: assert(0);
     }
 
-    laik_log(1, "allocated memory for '%s'/%d: %llu x %d (%llu B) at %p"
-             "\n  layout: %dd, strides (%llu/%llu/%llu)",
-             d->name, m->mapNo, (unsigned long long int) m->count, d->elemsize,
-             (unsigned long long) m->capacity, (void*) m->base,
-             m->layout->dims,
-             (unsigned long long) m->layout->stride[0],
-             (unsigned long long) m->layout->stride[1],
-             (unsigned long long) m->layout->stride[2]);
+    laik_log(LAIK_LL_Debug,
+             "allocated memory for '%s'/%d: %llu x %d (%llu B) at %p" "\n  layout: %dd, strides (%llu/%llu/%llu)",
+             d->name, m->mapNo, (unsigned long long int)m->count, d->elemsize,
+             (unsigned long long)m->capacity, (void *)m->base,
+             m->layout->dims, (unsigned long long)m->layout->stride[0],
+             (unsigned long long)m->layout->stride[1],
+             (unsigned long long)m->layout->stride[2]);
 }
 
 static
@@ -496,7 +498,7 @@ void copyMaps(Laik_Transition* t,
             assert(fromMap->base + fromOff * d->elemsize ==
                    toMap->base   + toOff * d->elemsize);
 
-            if (laik_log_begin(1)) {
+            if (laik_log_begin(LAIK_LL_Debug)) {
                 laik_log_append("copy map for '%s': (%lu x %lu x %lu)",
                                 d->name, count.i[0], count.i[1], count.i[2]);
                 laik_log_append(" x %d from global (", d->elemsize);
@@ -521,7 +523,7 @@ void copyMaps(Laik_Transition* t,
         char*    fromPtr  = fromMap->base + fromOff * d->elemsize;
         char*    toPtr    = toMap->base   + toOff * d->elemsize;
 
-        if (laik_log_begin(1)) {
+        if (laik_log_begin(LAIK_LL_Debug)) {
             laik_log_append("copy map for '%s': (%lu x %lu x %lu)",
                             d->name, count.i[0], count.i[1], count.i[2]);
             laik_log_append(" x %d from global (", d->elemsize);
@@ -621,7 +623,7 @@ void checkMapReuse(Laik_MappingList* toList, Laik_MappingList* fromList)
             // mark as reused by slice <i>: this prohibits delete of memory
             fromMap->reusedFor = i;
 
-            if (laik_log_begin(1)) {
+            if (laik_log_begin(LAIK_LL_Debug)) {
                 laik_log_append("map reuse for '%s'/%d ", toMap->data->name, i);
                 laik_log_Slice(dims, &(toMap->requiredSlice));
                 laik_log_append(" (in ");
@@ -682,8 +684,10 @@ void initMaps(Laik_Transition* t,
             assert(0);
         }
 
-        laik_log(1, "init map for '%s' slc/map %d/%d: %d entries in [%d;%d[ from %p\n",
-                 d->name, op->sliceNo, op->mapNo, elemCount, from, to, (void*) toBase);
+        laik_log(LAIK_LL_Debug,
+                 "init map for '%s' slc/map %d/%d: %d entries in [%d;%d[ from %p\n",
+                 d->name, op->sliceNo, op->mapNo, elemCount, from, to,
+                 (void *)toBase);
     }
 }
 
@@ -995,7 +999,7 @@ void laik_reservation_alloc(Laik_Reservation* res)
 
     free(glist);
 
-    laik_log(2, "Allocated reservations for '%s'", data->name);
+    laik_log(LAIK_LL_Info, "Allocated reservations for '%s'", data->name);
 
     // (4) set final sizes of base mappings, and do allocation
     for(int i = 0; i < mCount; i++) {
@@ -1011,7 +1015,7 @@ void laik_reservation_alloc(Laik_Reservation* res)
 
         laik_allocateMap(m, data->stat);
 
-        if (laik_log_begin(2)) {
+        if (laik_log_begin(LAIK_LL_Info)) {
             laik_log_append(" map [%d] ", m->mapNo);
             laik_log_Slice(dims, &(m->allocatedSlice));
             laik_log_flush(0);
@@ -1021,7 +1025,7 @@ void laik_reservation_alloc(Laik_Reservation* res)
     // (5) set parameters for embedded mappings
     for(int r = 0; r < res->count; r++) {
         Laik_Partitioning* p = res->entry[r].p;
-        laik_log(2, " part '%s':", p->name);
+        laik_log(LAIK_LL_Info, " part '%s':", p->name);
         for(int mapNo = 0; mapNo < p->myMapCount; mapNo++) {
             Laik_Mapping* m = &(res->entry[r].mList->map[mapNo]);
 
@@ -1036,7 +1040,7 @@ void laik_reservation_alloc(Laik_Reservation* res)
 
             initEmbeddedMapping(m, m->baseMapping);
 
-            if (laik_log_begin(2)) {
+            if (laik_log_begin(LAIK_LL_Info)) {
                 laik_log_append("  [%d] ", m->mapNo);
                 laik_log_Slice(dims, &(m->requiredSlice));
                 laik_log_flush(" in map [%d] with byte-off %llu",
@@ -1050,7 +1054,7 @@ void laik_reservation_alloc(Laik_Reservation* res)
 // execute a previously calculated transition on a data container
 void laik_exec_transition(Laik_Data* d, Laik_Transition* t)
 {
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("exec transition (");
         laik_log_DataFlow(t->fromFlow);
         laik_log_append("/'%s' => ", t->fromPartitioning ? t->fromPartitioning->name : "(none)");
@@ -1104,7 +1108,7 @@ void laik_exec_actions(Laik_ActionSeq* as)
     Laik_Transition* t = tc->transition;
     Laik_Data* d = tc->data;
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("exec actions for (");
         laik_log_DataFlow(t->fromFlow);
         laik_log_append("/'%s' => ", t->fromPartitioning ? t->fromPartitioning->name : "(none)");
@@ -1171,7 +1175,7 @@ void laik_switchto_partitioning(Laik_Data* d,
 
     if (toFlow == LAIK_DF_Previous) {
         if (laik_do_copyout(d->activeFlow) || laik_is_reduction(d->activeFlow))
-            toFlow = LAIK_DF_CopyIn | LAIK_DF_CopyOut;
+            toFlow = (Laik_DataFlow)((int)LAIK_DF_CopyIn | (int)LAIK_DF_CopyOut);
         else
             toFlow = LAIK_DF_None;
     }
@@ -1220,7 +1224,7 @@ void laik_switchto_phase(Laik_Data* d,
                                               fromP, d->activeFlow,
                                               toP, toFlow);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("switch access phase for data '%s':\n"
                         "  %s/",
                         d->name, fromAP ? fromAP->name : "(none)");
@@ -1287,7 +1291,7 @@ Laik_AccessPhase* laik_switchto_new_phase(Laik_Data* d, Laik_Group* g,
     Laik_AccessPhase* ap;
     ap = laik_new_accessphase(g, d->space, pr, 0);
 
-    laik_log(1, "switch data '%s' to new access phase '%s'",
+    laik_log(LAIK_LL_Debug, "switch data '%s' to new access phase '%s'",
              d->name, ap->name);
 
     laik_switchto_phase(d, ap, flow);
@@ -1301,8 +1305,9 @@ void laik_migrate_data(Laik_Data* d, Laik_Group* g)
     // we only support migration if data does not need to preserved
     assert(!laik_do_copyout(d->activeFlow));
 
-    laik_log(1, "migrate data '%s' => group %d (size %d, myid %d)",
-             d->name, g->gid, g->size, g->myid);
+    laik_log(LAIK_LL_Debug,
+             "migrate data '%s' => group %d (size %d, myid %d)", d->name,
+             g->gid, g->size, g->myid);
 
     // switch to invalid partitioning
     laik_switchto_phase(d, 0, LAIK_DF_None);
@@ -1435,7 +1440,7 @@ int laik_pack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
     // elements to skip after to1 reached
     int64_t skip1 = m->layout->stride[2] - m->layout->stride[1] * (to1 - from1);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         Laik_Index slcsize, localFrom;
         laik_sub_index(&localFrom, &(s->from), &(m->requiredSlice.from));
         laik_sub_index(&slcsize, &(s->to), &(s->from));
@@ -1461,10 +1466,10 @@ int laik_pack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                 }
 
 #if DEBUG_PACK
-                laik_log(1, "packing (%lu/%lu/%lu) off %lu: %.3f, left %d",
-                         i0, i1, i2,
-                         (idxPtr - m->base)/elemsize, *(double*)idxPtr,
-                         size - elemsize);
+                laik_log(LAIK_LL_Debug,
+                         "packing (%lu/%lu/%lu) off %lu: %.3f, left %d", i0,
+                         i1, i2, (idxPtr - m->base) / elemsize,
+                         *(double *)idxPtr, size - elemsize);
 #endif
 
                 // copy element into buffer
@@ -1490,7 +1495,7 @@ int laik_pack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
         i1 = to1;
     }
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         Laik_Index idx2;
         laik_set_index(&idx2, i0, i1, i2);
 
@@ -1556,7 +1561,7 @@ int laik_unpack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
     // elements to skip after to1 reached
     uint64_t skip1 = m->layout->stride[2] - m->layout->stride[1] * (to1 - from1);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         Laik_Index slcsize, localFrom;
         laik_sub_index(&localFrom, &(s->from), &(m->requiredSlice.from));
         laik_sub_index(&slcsize, &(s->to), &(s->from));
@@ -1583,10 +1588,10 @@ int laik_unpack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
                 }
 
 #if DEBUG_UNPACK
-                laik_log(1, "unpacking (%lu/%lu/%lu) off %lu: %.3f, left %d",
-                         i0, i1, i2,
-                         (idxPtr - m->base)/elemsize, *(double*)buf,
-                         size - elemsize);
+                laik_log(LAIK_LL_Debug,
+                         "unpacking (%lu/%lu/%lu) off %lu: %.3f, left %d", i0,
+                         i1, i2, (idxPtr - m->base) / elemsize,
+                         *(double *)buf, size - elemsize);
 #endif
                 // copy element from buffer into local data
                 memcpy(idxPtr, buf, elemsize);
@@ -1611,7 +1616,7 @@ int laik_unpack_def(const Laik_Mapping* m, const Laik_Slice* s, Laik_Index* idx,
         i1 = to1;
     }
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         Laik_Index idx2;
         laik_set_index(&idx2, i0, i1, i2);
 

--- a/src/partitioner.c
+++ b/src/partitioner.c
@@ -66,7 +66,7 @@ void runAllPartitioner(Laik_Partitioner* pr,
 
 Laik_Partitioner* laik_new_all_partitioner()
 {
-    return laik_new_partitioner("all", runAllPartitioner, 0, 0);
+    return laik_new_partitioner("all", runAllPartitioner, 0, LAIK_PF_None);
 }
 
 // master-partitioner: only task 0 has access to all indexes
@@ -83,7 +83,8 @@ void runMasterPartitioner(Laik_Partitioner* pr,
 
 Laik_Partitioner* laik_new_master_partitioner()
 {
-    return laik_new_partitioner("master", runMasterPartitioner, 0, 0);
+    return laik_new_partitioner("master", runMasterPartitioner, 0,
+                                LAIK_PF_None);
 }
 
 // copy-partitioner: copy the borders from base partitioning
@@ -132,7 +133,8 @@ Laik_Partitioner* laik_new_copy_partitioner(int fromDim, int toDim)
     data->fromDim = fromDim;
     data->toDim = toDim;
 
-    return laik_new_partitioner("copy", runCopyPartitioner, data, 0);
+    return laik_new_partitioner("copy", runCopyPartitioner, data,
+                                LAIK_PF_None);
 }
 
 
@@ -182,8 +184,8 @@ Laik_Partitioner* laik_new_cornerhalo_partitioner(int depth)
     assert(data);
     *data = depth;
 
-    return laik_new_partitioner("cornerhalo",
-                                runCornerHaloPartitioner, data, 0);
+    return laik_new_partitioner("cornerhalo", runCornerHaloPartitioner, data,
+                                LAIK_PF_None);
 }
 
 
@@ -261,7 +263,8 @@ Laik_Partitioner* laik_new_halo_partitioner(int depth)
     assert(data);
     *data = depth;
 
-    return laik_new_partitioner("halo", runHaloPartitioner, data, 0);
+    return laik_new_partitioner("halo", runHaloPartitioner, data,
+                                LAIK_PF_None);
 }
 
 
@@ -324,7 +327,8 @@ void runBisectionPartitioner(Laik_Partitioner* pr,
 
 Laik_Partitioner* laik_new_bisection_partitioner()
 {
-    return laik_new_partitioner("bisection", runBisectionPartitioner, 0, 0);
+    return laik_new_partitioner("bisection", runBisectionPartitioner, 0,
+                                LAIK_PF_None);
 }
 
 
@@ -465,7 +469,8 @@ Laik_Partitioner* laik_new_block_partitioner(int pdim, int cycles,
     data->userData = userData;
     data->getTaskW = tfunc;
 
-    return laik_new_partitioner("block", runBlockPartitioner, data, 0);
+    return laik_new_partitioner("block", runBlockPartitioner, data,
+                                LAIK_PF_None);
 }
 
 Laik_Partitioner* laik_new_block_partitioner1()
@@ -573,7 +578,8 @@ void runReassignPartitioner(Laik_Partitioner* pr,
     double weight = 0;
     int curTask = 0; // task in new group which gets the next indexes
 
-    laik_log(1, "reassign: re-distribute weight %.3f to %d tasks (%.3f per task)",
+    laik_log(LAIK_LL_Debug,
+             "reassign: re-distribute weight %.3f to %d tasks (%.3f per task)",
              totalWeight, newg->size, weightPerTask);
 
     Laik_Slice slc;
@@ -581,11 +587,11 @@ void runReassignPartitioner(Laik_Partitioner* pr,
         int origTask = oldP->tslice[sliceNo].task;
         if (newg->fromParent[origTask] >= 0) {
             // move over to new borders
-            laik_log(1, "reassign: take over slice %d of task %d "
-                     "(new task %d, indexes [%lld;%lld[)",
+            laik_log(LAIK_LL_Debug,
+                     "reassign: take over slice %d of task %d " "(new task %d, indexes [%lld;%lld[)",
                      sliceNo, origTask, newg->fromParent[origTask],
-                     (long long int) oldP->tslice[sliceNo].s.from.i[0],
-                     (long long int) oldP->tslice[sliceNo].s.to.i[0]);
+                     (long long int)oldP->tslice[sliceNo].s.from.i[0],
+                     (long long int)oldP->tslice[sliceNo].s.to.i[0]);
 
             laik_append_slice(p, origTask, &(oldP->tslice[sliceNo].s), 0, 0);
             continue;
@@ -609,10 +615,10 @@ void runReassignPartitioner(Laik_Partitioner* pr,
                 slc.to.i[0] = i + 1;
                 laik_append_slice(p, newg->toParent[curTask], &slc, 0, 0);
 
-                laik_log(1, "reassign: re-distribute [%lld;%lld[ "
-                         "of slice %d to task %d (new task %d)",
-                         (long long int) slc.from.i[0],
-                         (long long int) slc.to.i[0], sliceNo,
+                laik_log(LAIK_LL_Debug,
+                         "reassign: re-distribute [%lld;%lld[ " "of slice %d to task %d (new task %d)",
+                         (long long int)slc.from.i[0],
+                         (long long int)slc.to.i[0], sliceNo,
                          newg->toParent[curTask], curTask);
 
                 // start new slice
@@ -629,11 +635,10 @@ void runReassignPartitioner(Laik_Partitioner* pr,
             slc.to.i[0] = to;
             laik_append_slice(p, newg->toParent[curTask], &slc, 0, 0);
 
-            laik_log(1, "reassign: re-distribute remaining [%lld;%lld[ "
-                     "of slice %d to task %d (new task %d)",
-                     (long long int) slc.from.i[0],
-                     (long long int) slc.to.i[0], sliceNo,
-                     newg->toParent[curTask], curTask);
+            laik_log(LAIK_LL_Debug,
+                     "reassign: re-distribute remaining [%lld;%lld[ " "of slice %d to task %d (new task %d)",
+                     (long long int)slc.from.i[0], (long long int)slc.to.i[0],
+                     sliceNo, newg->toParent[curTask], curTask);
         }
     }
 }
@@ -653,6 +658,6 @@ laik_new_reassign_partitioner(Laik_Group* newg,
     data->getIdxW = getIdxW;
     data->userData = userData;
 
-    return laik_new_partitioner("reassign", runReassignPartitioner,
-                                data, 0);
+    return laik_new_partitioner("reassign", runReassignPartitioner, data,
+                                LAIK_PF_None);
 }

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -408,7 +408,7 @@ void updatePartitioningOffsetsSI(Laik_Partitioning* p)
         idx = p->tss1d[i].idx;
         count++;
     }
-    laik_log(1, "Merging single indexes: %d original, %d merged",
+    laik_log(LAIK_LL_Debug, "Merging single indexes: %d original, %d merged",
              p->count, count);
 
     p->tslice = malloc(sizeof(Laik_TaskSlice_Gen) * count);
@@ -429,9 +429,9 @@ void updatePartitioningOffsetsSI(Laik_Partitioning* p)
                 continue;
             }
         }
-        laik_log(1, "  adding slice for offsets %d - %d: task %d, [%lld;%lld[",
-                 j, i-1, task,
-                 (long long) idx0, (long long) (idx + 1) );
+        laik_log(LAIK_LL_Debug,
+                 "  adding slice for offsets %d - %d: task %d, [%lld;%lld[",
+                 j, i - 1, task, (long long)idx0, (long long)(idx + 1));
 
         Laik_TaskSlice_Gen* ts = &(p->tslice[off]);
         ts->type = TS_Generic;
@@ -647,7 +647,7 @@ bool laik_partitioning_coversSpace(Laik_Partitioning* p)
         Laik_Slice* toRemove = &(list[i].s);
 
 #ifdef DEBUG_COVERSPACE
-        if (laik_log_begin(1)) {
+        if (laik_log_begin(LAIK_LL_Debug)) {
             laik_log_append("coversSpace - ");
             log_Notcovered(dims, toRemove);
             laik_log_flush(0);
@@ -699,7 +699,7 @@ bool laik_partitioning_coversSpace(Laik_Partitioning* p)
     }
 
 #ifdef DEBUG_COVERSPACE
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("coversSpace - remaining ");
         log_Notcovered(dims, 0);
         laik_log_flush(0);
@@ -771,7 +771,7 @@ Laik_Partitioning* laik_new_partitioning(Laik_Partitioner* pr,
         updatePartitioningOffsets(p);
     }
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("run partitioner '%s' (group %d, myid %d, space '%s'):",
                         pr->name, g->gid, g->myid, space->name);
         laik_log_append("\n  other: ");
@@ -781,7 +781,8 @@ Laik_Partitioning* laik_new_partitioning(Laik_Partitioner* pr,
         laik_log_flush(0);
     }
     else
-        laik_log(2, "run partitioner '%s' (group %d, space '%s'): %d slices",
+        laik_log(LAIK_LL_Info,
+                 "run partitioner '%s' (group %d, space '%s'): %d slices",
                  pr->name, g->gid, space->name, p->count);
 
 

--- a/src/space.c
+++ b/src/space.c
@@ -264,7 +264,7 @@ Laik_Space* laik_new_space_1d(Laik_Instance* i, int64_t s1)
     space->s.from.i[0] = 0;
     space->s.to.i[0] = s1;
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("new 1d space '%s': ", space->name);
         laik_log_Space(space);
         laik_log_flush(0);
@@ -282,7 +282,7 @@ Laik_Space* laik_new_space_2d(Laik_Instance* i, int64_t s1, int64_t s2)
     space->s.from.i[1] = 0;
     space->s.to.i[1] = s2;
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("new 2d space '%s': ", space->name);
         laik_log_Space(space);
         laik_log_flush(0);
@@ -303,7 +303,7 @@ Laik_Space* laik_new_space_3d(Laik_Instance* i,
     space->s.from.i[2] = 0;
     space->s.to.i[2] = s3;
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("new 3d space '%s': ", space->name);
         laik_log_Space(space);
         laik_log_flush(0);
@@ -419,7 +419,7 @@ laik_new_accessphase(Laik_Group* group, Laik_Space* space,
         laik_addAccessPhaseForBase(base, ap);
     }
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("new access phase '%s':\n  space '%s', "
                         "group %d (size %d, myid %d), partitioner '%s'",
                         ap->name, space->name,
@@ -653,7 +653,7 @@ void laik_phase_set_partitioning(Laik_AccessPhase* ap, Laik_Partitioning* p)
     assert(ap->group == p->group);
     assert(ap->space == p->space);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("setting partitioning for access phase '%s' (group %d, myid %d):\n  ",
                         ap->name, p->group->gid, p->group->myid);
         laik_log_Partitioning(p);
@@ -662,7 +662,8 @@ void laik_phase_set_partitioning(Laik_AccessPhase* ap, Laik_Partitioning* p)
 
     if (ap->hasValidPartitioning &&
         laik_partitioning_isEqual(ap->partitioning, p)) {
-        laik_log(1, "partitioning equal to original, nothing to do");
+        laik_log(LAIK_LL_Debug,
+                 "partitioning equal to original, nothing to do");
         return;
     }
 
@@ -892,8 +893,9 @@ void appendBorder(int64_t b, int task, int sliceNo, int mapNo,
     sb->isInput = isInput ? 1 : 0;
 
 #ifdef DEBUG_REDUCTIONSLICES
-    laik_log(1, "  add border %lld, task %d slice/map %d/%d (%s, %s)",
-             (long long int) b, task, sliceNo, mapNo,
+    laik_log(LAIK_LL_Debug,
+             "  add border %lld, task %d slice/map %d/%d (%s, %s)",
+             (long long int)b, task, sliceNo, mapNo,
              isStart ? "start" : "end", isInput ? "input" : "output");
 #endif
 }
@@ -1127,7 +1129,7 @@ void calcAddReductions(int tflags,
                        Laik_ReductionOperation redOp,
                        Laik_Partitioning* fromP, Laik_Partitioning* toP)
 {
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_append("calc '");
         laik_log_Reduction(redOp);
         laik_log_flush("' reduction actions:");
@@ -1193,8 +1195,9 @@ void calcAddReductions(int tflags,
         SliceBorder* sb = &(borderList[i]);
 
 #ifdef DEBUG_REDUCTIONSLICES
-        laik_log(1, "at border %lld, task %d (slice %d, map %d): %s for %s",
-                 (long long int) sb->b, sb->task, sb->sliceNo, sb->mapNo,
+        laik_log(LAIK_LL_Debug,
+                 "at border %lld, task %d (slice %d, map %d): %s for %s",
+                 (long long int)sb->b, sb->task, sb->sliceNo, sb->mapNo,
                  sb->isStart ? "start" : "end",
                  sb->isInput ? "input" : "output");
 #endif
@@ -1237,9 +1240,9 @@ void calcAddReductions(int tflags,
 
 #ifdef DEBUG_REDUCTIONSLICES
             char* act[] = {"(none)", "input", "output", "in & out"};
-            laik_log(1, "  range (%lld - %lld), my activity: %s",
-                     (long long int) sb->b,
-                     (long long int) nextBorder, act[myActivity]);
+            laik_log(LAIK_LL_Debug, "  range (%lld - %lld), my activity: %s",
+                     (long long int)sb->b, (long long int)nextBorder,
+                     act[myActivity]);
 #endif
 
             if (myActivity > 0) {
@@ -1263,10 +1266,10 @@ void calcAddReductions(int tflags,
                                            myInputSliceNo, myOutputSliceNo,
                                            myInputMapNo, myOutputMapNo);
 #ifdef DEBUG_REDUCTIONSLICES
-                            laik_log(1, "  adding local (special reduction)"
-                                        " (%lld - %lld) from %d/%d to %d/%d (slc/map)",
-                                     (long long int) slc.from.i[0],
-                                     (long long int) slc.to.i[0],
+                            laik_log(LAIK_LL_Debug,
+                                     "  adding local (special reduction)" " (%lld - %lld) from %d/%d to %d/%d (slc/map)",
+                                     (long long int)slc.from.i[0],
+                                     (long long int)slc.to.i[0],
                                      myInputSliceNo, myInputMapNo,
                                      myOutputSliceNo, myOutputMapNo);
 #endif
@@ -1283,12 +1286,12 @@ void calcAddReductions(int tflags,
                                                    myInputSliceNo, myOutputSliceNo,
                                                    myInputMapNo, myOutputMapNo);
 #ifdef DEBUG_REDUCTIONSLICES
-                                    laik_log(1, "  adding local (special reduction)"
-                                                " (%lld - %lld) from %d/%d to %d/%d (slc/map)",
-                                             (long long int) slc.from.i[0],
-                                            (long long int) slc.to.i[0],
-                                            myInputSliceNo, myInputMapNo,
-                                            myOutputSliceNo, myOutputMapNo);
+                                    laik_log(LAIK_LL_Debug,
+                                             "  adding local (special reduction)" " (%lld - %lld) from %d/%d to %d/%d (slc/map)",
+                                             (long long int)slc.from.i[0],
+                                             (long long int)slc.to.i[0],
+                                             myInputSliceNo, myInputMapNo,
+                                             myOutputSliceNo, myOutputMapNo);
 #endif
                                     continue;
                                 }
@@ -1299,12 +1302,12 @@ void calcAddReductions(int tflags,
                                               myInputSliceNo, myInputMapNo,
                                               outputGroup.task[out]);
 #ifdef DEBUG_REDUCTIONSLICES
-                                laik_log(1, "  adding send (special reduction)"
-                                            " (%lld - %lld) slc/map %d/%d to T%d",
-                                         (long long int) slc.from.i[0],
-                                        (long long int) slc.to.i[0],
-                                        myInputSliceNo, myInputMapNo,
-                                        outputGroup.task[out]);
+                                laik_log(LAIK_LL_Debug,
+                                         "  adding send (special reduction)" " (%lld - %lld) slc/map %d/%d to T%d",
+                                         (long long int)slc.from.i[0],
+                                         (long long int)slc.to.i[0],
+                                         myInputSliceNo, myInputMapNo,
+                                         outputGroup.task[out]);
 #endif
                             }
                             continue;
@@ -1323,12 +1326,12 @@ void calcAddReductions(int tflags,
                                               inputGroup.task[0]);
 
 #ifdef DEBUG_REDUCTIONSLICES
-                                laik_log(1, "  adding recv (special reduction)"
-                                            " (%lld - %lld) slc/map %d/%d from T%d",
-                                         (long long int) slc.from.i[0],
-                                        (long long int) slc.to.i[0],
-                                        myOutputSliceNo, myOutputMapNo,
-                                        inputGroup.task[0]);
+                                laik_log(LAIK_LL_Debug,
+                                         "  adding recv (special reduction)" " (%lld - %lld) slc/map %d/%d from T%d",
+                                         (long long int)slc.from.i[0],
+                                         (long long int)slc.to.i[0],
+                                         myOutputSliceNo, myOutputMapNo,
+                                         inputGroup.task[0]);
 #endif
                             }
                             // handled cases with 1 input
@@ -1343,7 +1346,7 @@ void calcAddReductions(int tflags,
                 int out = getTaskGroup(&outputGroup);
 
 #ifdef DEBUG_REDUCTIONSLICES
-                laik_log_begin(1);
+                laik_log_begin(LAIK_LL_Debug);
                 laik_log_append("  adding reduction (%lu - %lu), in %d:(",
                                 slc.from.i[0], slc.to.i[0], in);
                 for(int i = 0; i < groupList[in].count; i++) {
@@ -1669,7 +1672,7 @@ laik_calc_transition(Laik_Space* space,
     }
     assert(tList == ((char*)t) + tsize);
 
-    if (laik_log_begin(1)) {
+    if (laik_log_begin(LAIK_LL_Debug)) {
         laik_log_Transition(t, true);
         laik_log_flush(0);
     }

--- a/tools/coccinelle/Laik_PartitionerFlag.patch
+++ b/tools/coccinelle/Laik_PartitionerFlag.patch
@@ -1,0 +1,5 @@
+@@
+expression a, b;
+@@
+- LAIK_PF_Merge | (a ? LAIK_PF_SingleIndex : 0) | (b ? LAIK_PF_Compact : 0)
++ (Laik_PartitionerFlag) ((int) LAIK_PF_Merge | (a ? LAIK_PF_SingleIndex : 0) | (b ? LAIK_PF_Compact : 0))

--- a/tools/coccinelle/README.md
+++ b/tools/coccinelle/README.md
@@ -1,0 +1,38 @@
+# Installing coccinelle
+
+coccinelle is probably already packaged for your distribution, look for a
+package called ```coccinelle```. Otherwise, you can of course also compile it
+from source from upstream[^0].
+
+# Writing coccinelle patches
+
+This blog post[^1] is a good first step to understand the basic ideas behind
+coccinelle. For a more advanced discussion, you might want to read the LWN
+article[^2] or watch a talk from one of the authors[^3]. Furthermore, there is
+an official example gallery[^4] and quite a few projects already use coccinelle,
+for example systemd[^5] or the Linux kernel[^6], so you might wanna check out
+how they solve a particular problem. Finally, the language is well-documented,
+so have a look at the language grammar[^7]!
+
+# Running coccinelle
+
+You can either apply a specific patch...
+
+    $ tools/coccinelle/coccinelle.sh /path/to/your/coccinelle.patch
+    [...]
+    $
+
+... or simply apply all of LAIK's stored patches on the source tree:
+
+    $ tools/coccinelle/coccinelle.sh
+    [...]
+    $
+
+[^0]: <http://coccinelle.lip6.fr/>
+[^1]: <https://home.regit.org/technical-articles/coccinelle-for-the-newbie/>
+[^2]: <https://lwn.net/Articles/315686/>
+[^3]: <https://www.youtube.com/watch?v=buZrNd6XkEw>
+[^4]: <http://coccinellery.org/>
+[^5]: <https://github.com/systemd/systemd/tree/master/coccinelle>
+[^6]: <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/coccinelle>
+[^7]: <http://coccinelle.lip6.fr/docs/main_grammar.html>

--- a/tools/coccinelle/coccinelle.sh
+++ b/tools/coccinelle/coccinelle.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -eu
+
+DIR="`dirname -- "${0}"`"
+SRC="${DIR}/../.."
+
+# Without any arguments, apply all patches
+if [ "${#}" -eq 0 ]; then
+    set -- "${DIR}"/*.patch
+fi
+
+# Apply the selected set of patches
+for patch in "${@}"; do
+    echo "Applying ${patch}"
+
+    for dir in 'examples' 'external' 'src'; do
+        spatch \
+            --dir "${SRC}/${dir}" \
+            --in-place \
+            --sp-file "${patch}" \
+            --very-quiet
+    done
+done

--- a/tools/coccinelle/laik_DataFlow.patch
+++ b/tools/coccinelle/laik_DataFlow.patch
@@ -1,0 +1,12 @@
+@@
+@@
+- LAIK_DF_CopyIn | LAIK_DF_CopyOut
++ (Laik_DataFlow) ((int) LAIK_DF_CopyIn | (int) LAIK_DF_CopyOut)
+@@
+@@
+- LAIK_DF_ReduceOut | LAIK_DF_Sum
++ (Laik_DataFlow) ((int) LAIK_DF_ReduceOut | (int) LAIK_DF_Sum)
+@@
+@@
+- LAIK_DF_Init | LAIK_DF_ReduceOut | LAIK_DF_Sum
++ (Laik_DataFlow) ((int) LAIK_DF_Init | (int) LAIK_DF_ReduceOut | (int) LAIK_DF_Sum)

--- a/tools/coccinelle/laik_log.patch
+++ b/tools/coccinelle/laik_log.patch
@@ -1,0 +1,30 @@
+@@
+expression list a;
+@@
+- laik_log (0, a)
++ laik_log (LAIK_LL_None, a)
+@@
+expression list a;
+@@
+- laik_log (1, a)
++ laik_log (LAIK_LL_Debug, a)
+@@
+expression list a;
+@@
+- laik_log (2, a)
++ laik_log (LAIK_LL_Info, a)
+@@
+expression list a;
+@@
+- laik_log (3, a)
++ laik_log (LAIK_LL_Warning, a)
+@@
+expression list a;
+@@
+- laik_log (4, a)
++ laik_log (LAIK_LL_Error, a)
+@@
+expression list a;
+@@
+- laik_log (5, a)
++ laik_log (LAIK_LL_Panic, a)

--- a/tools/coccinelle/laik_log_begin.patch
+++ b/tools/coccinelle/laik_log_begin.patch
@@ -1,0 +1,24 @@
+@@
+@@
+- laik_log_begin (0)
++ laik_log_begin (LAIK_LL_None)
+@@
+@@
+- laik_log_begin (1)
++ laik_log_begin (LAIK_LL_Debug)
+@@
+@@
+- laik_log_begin (2)
++ laik_log_begin (LAIK_LL_Info)
+@@
+@@
+- laik_log_begin (3)
++ laik_log_begin (LAIK_LL_Warning)
+@@
+@@
+- laik_log_begin (4)
++ laik_log_begin (LAIK_LL_Error)
+@@
+@@
+- laik_log_begin (5)
++ laik_log_begin (LAIK_LL_Panic)

--- a/tools/coccinelle/laik_logshown.patch
+++ b/tools/coccinelle/laik_logshown.patch
@@ -1,0 +1,24 @@
+@@
+@@
+- laik_logshown (0)
++ laik_logshown (LAIK_LL_None)
+@@
+@@
+- laik_logshown (1)
++ laik_logshown (LAIK_LL_Debug)
+@@
+@@
+- laik_logshown (2)
++ laik_logshown (LAIK_LL_Info)
+@@
+@@
+- laik_logshown (3)
++ laik_logshown (LAIK_LL_Warning)
+@@
+@@
+- laik_logshown (4)
++ laik_logshown (LAIK_LL_Error)
+@@
+@@
+- laik_logshown (5)
++ laik_logshown (LAIK_LL_Panic)

--- a/tools/coccinelle/laik_new_partitioner.patch
+++ b/tools/coccinelle/laik_new_partitioner.patch
@@ -1,0 +1,5 @@
+@@
+expression a, b, c;
+@@
+- laik_new_partitioner (a, b, c, 0)
++ laik_new_partitioner (a, b, c, LAIK_PF_None)

--- a/tools/coccinelle/laik_set_loglevel.patch
+++ b/tools/coccinelle/laik_set_loglevel.patch
@@ -1,0 +1,24 @@
+@@
+@@
+- laik_set_loglevel (0)
++ laik_set_loglevel (LAIK_LL_None)
+@@
+@@
+- laik_set_loglevel (1)
++ laik_set_loglevel (LAIK_LL_Debug)
+@@
+@@
+- laik_set_loglevel (2)
++ laik_set_loglevel (LAIK_LL_Info)
+@@
+@@
+- laik_set_loglevel (3)
++ laik_set_loglevel (LAIK_LL_Warning)
+@@
+@@
+- laik_set_loglevel (4)
++ laik_set_loglevel (LAIK_LL_Error)
+@@
+@@
+- laik_set_loglevel (5)
++ laik_set_loglevel (LAIK_LL_Panic)

--- a/tools/coccinelle/laik_switchto_phase.patch
+++ b/tools/coccinelle/laik_switchto_phase.patch
@@ -1,0 +1,5 @@
+@@
+expression a, b;
+@@
+- laik_switchto_phase (a, b, 0)
++ laik_switchto_phase (a, b, LAIK_DF_None)


### PR DESCRIPTION
With this and #139 and #140, building with CMake/ICC finally works on the SuperMUC:

```
$ mkdir build
$ cd build
$ module unload cmake && module load cmake/3.6
$ CC=icc CXX=icpc cmake ..
-- The C compiler identification is Intel 16.0.4.20160811
-- The CXX compiler identification is Intel 16.0.4.20160811
-- Check for working C compiler: /lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/bin/intel64/icc
-- Check for working C compiler: /lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/bin/intel64/icc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/bin/intel64/icpc
-- Check for working CXX compiler: /lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/bin/intel64/icpc -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Dependency check for option 'documentation' failed, skipping!
-- Try OpenMP C flag = [-qopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Try OpenMP CXX flag = [-qopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Found OpenMP: -qopenmp  
-- Dependency check for option 'openmp-examples' succeeded, building!
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.23") 
-- Checking for module 'libprotobuf-c'
--   No package 'libprotobuf-c' found
-- Dependency check for option 'failure-simulator' failed, skipping!
-- Dependency check for option 'mosquitto-agent' failed, skipping!
-- Checking for module 'papi'
--   No package 'papi' found
-- Dependency check for option 'profiling-agent' failed, skipping!
-- Checking for module 'mpi'
--   No package 'mpi' found
-- Found MPI_C: /opt/ibmhpc/pecurrent/mpich2/intel/lib64/libmpi.so;/usr/lib64/libdl.so;/lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/compiler/lib/intel64_lin/libirc.so;/usr/lib64/libpthread.so;/usr/lib64/librt.so  
-- Found MPI_CXX: /opt/ibmhpc/pecurrent/mpich2/intel/lib64/libmpi.so;/opt/ibmhpc/pecurrent/mpich2/intel/lib64/libmpigc4.so;/usr/lib64/libdl.so;/lrz/sys/intel/studio2016_u4/compilers_and_libraries_2016.4.258/linux/compiler/lib/intel64_lin/libirc.so;/usr/lib64/libpthread.so;/usr/lib64/librt.so  
-- Dependency check for option 'mpi-backend' succeeded, building!
-- Checking for module 'gio-2.0>=2.44'
--   
-- Checking for module 'glib-2.0>=2.44'
--   
-- Dependency check for option 'tcp-backend' failed, skipping!
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hpc/pr27ne/ga39pid3/kurtz/laik/build
$ make
Scanning dependencies of target laik
[  2%] Building C object src/CMakeFiles/laik.dir/action.c.o
[  4%] Building C object src/CMakeFiles/laik.dir/backend.c.o
[  6%] Building C object src/CMakeFiles/laik.dir/core.c.o
remark #11074: Inlining inhibited by limit max-size 
remark #11076: To get full report use -qopt-report=4 -qopt-report-phase ipo
[  8%] Building C object src/CMakeFiles/laik.dir/data.c.o
remark #11074: Inlining inhibited by limit max-size 
remark #11076: To get full report use -qopt-report=4 -qopt-report-phase ipo
[ 10%] Building C object src/CMakeFiles/laik.dir/debug.c.o
[ 12%] Building C object src/CMakeFiles/laik.dir/external.c.o
[ 14%] Building C object src/CMakeFiles/laik.dir/partitioner.c.o
[ 17%] Building C object src/CMakeFiles/laik.dir/partitioning.c.o
[ 19%] Building C object src/CMakeFiles/laik.dir/profiling.c.o
[ 21%] Building C object src/CMakeFiles/laik.dir/program.c.o
[ 23%] Building C object src/CMakeFiles/laik.dir/space.c.o
remark #11074: Inlining inhibited by limit max-size 
remark #11076: To get full report use -qopt-report=4 -qopt-report-phase ipo
[ 25%] Building C object src/CMakeFiles/laik.dir/type.c.o
[ 27%] Building C object src/CMakeFiles/laik.dir/backend-mpi.c.o
remark #11074: Inlining inhibited by limit max-size 
remark #11076: To get full report use -qopt-report=4 -qopt-report-phase ipo
[ 29%] Building C object src/CMakeFiles/laik.dir/backend-single.c.o
[ 31%] Linking C shared library liblaik.so
[ 31%] Built target laik
Scanning dependencies of target raytracer
[ 34%] Building CXX object examples/CMakeFiles/raytracer.dir/c++/raytracer.cpp.o
remark #11074: Inlining inhibited by limit max-size 
remark #11076: To get full report use -qopt-report=4 -qopt-report-phase ipo
[ 36%] Linking CXX executable raytracer
[ 36%] Built target raytracer
Scanning dependencies of target markov
[ 38%] Building C object examples/CMakeFiles/markov.dir/markov.c.o
[ 40%] Linking C executable markov
[ 40%] Built target markov
Scanning dependencies of target markov2
[ 42%] Building C object examples/CMakeFiles/markov2.dir/markov2.c.o
[ 44%] Linking C executable markov2
[ 44%] Built target markov2
Scanning dependencies of target markov-ser
[ 46%] Building C object examples/CMakeFiles/markov-ser.dir/markov-ser.c.o
[ 48%] Linking C executable markov-ser
[ 48%] Built target markov-ser
Scanning dependencies of target spmv2
[ 51%] Building C object examples/CMakeFiles/spmv2.dir/spmv2.c.o
[ 53%] Linking C executable spmv2
[ 53%] Built target spmv2
Scanning dependencies of target spmv
[ 55%] Building C object examples/CMakeFiles/spmv.dir/spmv.c.o
[ 57%] Linking C executable spmv
[ 57%] Built target spmv
Scanning dependencies of target jac2d-ser
[ 59%] Building C object examples/CMakeFiles/jac2d-ser.dir/jac2d-ser.c.o
[ 61%] Linking C executable jac2d-ser
[ 61%] Built target jac2d-ser
Scanning dependencies of target propagation1d
[ 63%] Building C object examples/CMakeFiles/propagation1d.dir/propagation1d.c.o
[ 65%] Linking C executable propagation1d
[ 65%] Built target propagation1d
Scanning dependencies of target propagation2d
[ 68%] Building C object examples/CMakeFiles/propagation2d.dir/propagation2d.c.o
[ 70%] Linking C executable propagation2d
[ 70%] Built target propagation2d
Scanning dependencies of target jac1d
[ 72%] Building C object examples/CMakeFiles/jac1d.dir/jac1d.c.o
[ 74%] Linking C executable jac1d
[ 74%] Built target jac1d
Scanning dependencies of target jac2d
[ 76%] Building C object examples/CMakeFiles/jac2d.dir/jac2d.c.o
[ 78%] Linking C executable jac2d
[ 78%] Built target jac2d
Scanning dependencies of target jac3d
[ 80%] Building C object examples/CMakeFiles/jac3d.dir/jac3d.c.o
[ 82%] Linking C executable jac3d
[ 82%] Built target jac3d
Scanning dependencies of target vsum2
[ 85%] Building C object examples/CMakeFiles/vsum2.dir/vsum2.c.o
[ 87%] Linking C executable vsum2
[ 87%] Built target vsum2
Scanning dependencies of target vsum3
[ 89%] Building C object examples/CMakeFiles/vsum3.dir/vsum3.c.o
[ 91%] Linking C executable vsum3
[ 91%] Built target vsum3
Scanning dependencies of target vsum
[ 93%] Building C object examples/CMakeFiles/vsum.dir/vsum.c.o
[ 95%] Linking C executable vsum
[ 95%] Built target vsum
Scanning dependencies of target simpleagent
[ 97%] Building C object external/simple/CMakeFiles/simpleagent.dir/simple-agent.c.o
[100%] Linking C shared library libsimpleagent.so
[100%] Built target simpleagent
$ 
```