### PR TITLE
tools/iwyu/iwyu.sh: Set all optional preprocessor macros used by LAIK.

### DIFF
--- a/tools/iwyu/iwyu.sh
+++ b/tools/iwyu/iwyu.sh
@@ -16,6 +16,10 @@ done
 
 include-what-you-use \
     -Xiwyu --mapping_file="${DIR}/map.yaml" \
+    -D LAIK_TCP_DEBUG \
+    -D LAIK_TCP_STATS \
+    -D USE_MPI \
+    -D USE_TCP \
     -I "${SRC}/include" \
     -I "${SRC}/src" \
     "${@}"


### PR DESCRIPTION
We use preprocessor macros throughout LAIK to enable/disable portions of
the code, but the include directives must work with any combination of
those macros, so enable them all when calculating the include list with
IWYU.