### PR TITLE
CMakeLists.txt: Always undefine NDEBUG when building LAIK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_testing ()
 # Set some global defaults
 add_compile_options (
     "-pedantic"
+    "-UNDEBUG" # Work around https://github.com/envelope-project/laik/issues/92
     "-Wall"
     "-Werror"
     "-Wextra"


### PR DESCRIPTION
When using CMake, the recommend way to get an optimized build is to do a
release build via ```-D CMAKE_BUILD_TYPE=Release```. This adds ```-O3```
but also ```-DNDEBUG```, which unfortunately currently breaks LAIK (see
issue #92). Therefore, we now always undefine ```NDEBUG``` in the main
```CMakeLists.txt``` file until LAIK is fixed to work with ```NDEBUG```.