### PR TITLE
Fix some warnings emitted by GCC when compiling with -O3

### DIFF
--- a/examples/jac3d.c
+++ b/examples/jac3d.c
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
     bool do_exec = false;
     bool do_actions = false;
     bool do_grid = false;
-    int xblocks, yblocks, zblocks; // for grid partitioner
+    int xblocks = 0, yblocks = 0, zblocks = 0; // for grid partitioner
 
     int arg = 1;
     while ((argc > arg) && (argv[arg][0] == '-')) {

--- a/external/MQTT/mqttagent.c
+++ b/external/MQTT/mqttagent.c
@@ -28,7 +28,9 @@ static void free_backbuffer(
     pthread_mutex_lock(mutex);
     for(int i=0; i<num_failed; i++) free(failed_nodes[i]);
     num_failed = 0;
-    memset(failed_nodes, 0x0, MAX_FAILED_BUFFER*sizeof(node_uid_t*));
+    if (failed_nodes != NULL) {
+        memset(failed_nodes, 0x0, MAX_FAILED_BUFFER*sizeof(node_uid_t*));
+    }
     pthread_mutex_unlock(mutex);
 }
 

--- a/src/backend-mpi.c
+++ b/src/backend-mpi.c
@@ -882,7 +882,7 @@ void laik_execOrRecord(bool record,
             }
 
             MPI_Status s;
-            uint64_t count;
+            uint64_t count = 0;
 
             MPI_Datatype mpiDataType = getMPIDataType(data);
 
@@ -981,7 +981,7 @@ void laik_execOrRecord(bool record,
                 assert(0);
             }
 
-            uint64_t count;
+            uint64_t count = 0;
             MPI_Datatype mpiDataType = getMPIDataType(data);
 
             if (dims == 1) {


### PR DESCRIPTION
When compiling with ```-O3```, GCC warns about a few places where variables might be uninitialized and one call to ```memset()``` which may pass  a ```NULL``` as the first argument (which is forbidden by the header file [0]). For some reasons, both clang and GCC without ```-O3``` don't warn about these, so I only discovered them now.

[0]: /usr/include/string.h says:
```
extern void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
```