### PR TITLE
TCP Backend: Make the reductions a bit faster

### DIFF
--- a/src/backends/tcp/backend.c
+++ b/src/backends/tcp/backend.c
@@ -247,6 +247,14 @@ static bool laik_tcp_backend_native_reduce
 {
     laik_tcp_always (errors);
 
+    // Get the configuration
+    g_autoptr (Laik_Tcp_Config) config = laik_tcp_config ();
+
+    // If native reductions are disabled, return immediatly
+    if (!config->backend_native_reduce) {
+        return false;
+    }
+
     MPI_Op mpi_operation;
     switch (op) {
         case LAIK_RO_Sum:

--- a/src/backends/tcp/config.c
+++ b/src/backends/tcp/config.c
@@ -175,6 +175,7 @@ static Laik_Tcp_Config* laik_tcp_config_new_default (void) {
     *this = (Laik_Tcp_Config) {
         .addresses                 = g_steal_pointer (&addresses),
         .backend_async_send        = true,
+        .backend_peer_reduce       = true,
         .client_connections        = 64,
         .client_threads            = 4,
         .server_connections        = 64,
@@ -233,6 +234,7 @@ static Laik_Tcp_Config* laik_tcp_config_new_custom (Laik_Tcp_Errors* errors) {
         // Load the individual settings
         if (!laik_tcp_config_parse_addresses (keyfile, "addresses",                             &this->addresses,                 errors)) { return NULL; };
         if (!laik_tcp_config_parse_bool      (keyfile, "general",  "backend_async_send",        &this->backend_async_send,        errors)) { return NULL; };
+        if (!laik_tcp_config_parse_bool      (keyfile, "general",  "backend_peer_reduce",       &this->backend_peer_reduce,       errors)) { return NULL; };
         if (!laik_tcp_config_parse_size      (keyfile, "general",  "client_connections",        &this->client_connections,        errors)) { return NULL; };
         if (!laik_tcp_config_parse_size      (keyfile, "general",  "client_threads",            &this->client_threads,            errors)) { return NULL; };
         if (!laik_tcp_config_parse_size      (keyfile, "general",  "server_connections",        &this->server_connections,        errors)) { return NULL; };

--- a/src/backends/tcp/config.c
+++ b/src/backends/tcp/config.c
@@ -175,6 +175,7 @@ static Laik_Tcp_Config* laik_tcp_config_new_default (void) {
     *this = (Laik_Tcp_Config) {
         .addresses                 = g_steal_pointer (&addresses),
         .backend_async_send        = true,
+        .backend_native_reduce     = false,
         .backend_peer_reduce       = true,
         .client_connections        = 64,
         .client_threads            = 4,
@@ -234,6 +235,7 @@ static Laik_Tcp_Config* laik_tcp_config_new_custom (Laik_Tcp_Errors* errors) {
         // Load the individual settings
         if (!laik_tcp_config_parse_addresses (keyfile, "addresses",                             &this->addresses,                 errors)) { return NULL; };
         if (!laik_tcp_config_parse_bool      (keyfile, "general",  "backend_async_send",        &this->backend_async_send,        errors)) { return NULL; };
+        if (!laik_tcp_config_parse_bool      (keyfile, "general",  "backend_native_reduce",     &this->backend_native_reduce,     errors)) { return NULL; };
         if (!laik_tcp_config_parse_bool      (keyfile, "general",  "backend_peer_reduce",       &this->backend_peer_reduce,       errors)) { return NULL; };
         if (!laik_tcp_config_parse_size      (keyfile, "general",  "client_connections",        &this->client_connections,        errors)) { return NULL; };
         if (!laik_tcp_config_parse_size      (keyfile, "general",  "client_threads",            &this->client_threads,            errors)) { return NULL; };

--- a/src/backends/tcp/config.h
+++ b/src/backends/tcp/config.h
@@ -24,6 +24,7 @@
 typedef struct {
     GPtrArray* addresses;
     bool       backend_async_send;
+    bool       backend_native_reduce;
     bool       backend_peer_reduce;
     size_t     client_connections;
     size_t     client_threads;

--- a/src/backends/tcp/config.h
+++ b/src/backends/tcp/config.h
@@ -24,6 +24,7 @@
 typedef struct {
     GPtrArray* addresses;
     bool       backend_async_send;
+    bool       backend_peer_reduce;
     size_t     client_connections;
     size_t     client_threads;
     size_t     server_connections;

--- a/src/backends/tcp/config.txt
+++ b/src/backends/tcp/config.txt
@@ -3,6 +3,9 @@
 # Whether the backend should do the sends in parallel to the receive operations
 # backend_async_send = true
 
+# Whether reductions should be done on all output tasks instead of just one
+# backend_peer_reduce = true
+
 # How many connections to keep open concurrently
 # client_connections = 16
 

--- a/src/backends/tcp/config.txt
+++ b/src/backends/tcp/config.txt
@@ -3,6 +3,9 @@
 # Whether the backend should do the sends in parallel to the receive operations
 # backend_async_send = true
 
+# Whether to attempt to use native MPI reductions if possible
+# backend_native_reduce = false
+
 # Whether reductions should be done on all output tasks instead of just one
 # backend_peer_reduce = true
 


### PR DESCRIPTION
The evaluation has shown that the ```propagation2d``` and ```spmv2``` examples (which use a lot of reductions) are a lot slower on the TCP backend compared to the MPI backend. This PR attempts to tackle this problem by doing the reductions on all output task instead of choosing a dedicated reduction task which would then send the result back to all output tasks. The idea is that this avoids a global synchronization point, and preliminary evaluation results are promising!