### PR TITLE
Allow specifying the MPI implementation when building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ option (single-backend    "Enable Single backend"                               
 option (skip-missing      "Enable skipping optional features in the case of missing dependencies"       on)
 option (tcp-backend       "Enable TCP backend (needs libglib2.0-dev)"                                   on)
 
+set (mpi-implementation "mpi" CACHE STRING "The pkg-config name of the MPI implementation to use (defaults to 'mpi')")
+
 # Add a pandoc helper function
 function (add_pandoc_target target)
     add_custom_command (

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries ("laik"
 
 # Optional MPI backend
 if (mpi-backend)
-    find_pkgconfig ("mpi" "mpi")
+    find_pkgconfig ("mpi" "${mpi-implementation}")
 
     # If pkg-config didn't find MPI above, also try CMake's native FindMPI
     # module since we really want to enable MPI support whenever possible!

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -35,6 +35,13 @@ if ("USE_MPI" IN_LIST definitions)
         "test-vsum-mpi-1.sh"
         "test-vsum-mpi-4.sh"
     )
-        add_test ("mpi/${test}" "${CMAKE_CURRENT_SOURCE_DIR}/${test}")
+
+        if ("${mpi-implementation}" STREQUAL "ompi")
+            add_test ("mpi/${test}" "env" "MPIEXEC=mpiexec.openmpi --oversubscribe" "${CMAKE_CURRENT_SOURCE_DIR}/${test}")
+        elseif ("${mpi-implementation}" STREQUAL "mpich")
+            add_test ("mpi/${test}" "env" "MPIEXEC=mpiexec.mpich" "${CMAKE_CURRENT_SOURCE_DIR}/${test}")
+        else ()
+            add_test ("mpi/${test}" "${CMAKE_CURRENT_SOURCE_DIR}/${test}")
+        endif ()
     endforeach ()
 endif ()

--- a/tests/mpi/test-jac1d-100-mpi-1.sh
+++ b/tests/mpi/test-jac1d-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac1d 100 > test-jac1d-100-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/jac1d 100 > test-jac1d-100-mpi-1.out
 cmp test-jac1d-100-mpi-1.out "$(dirname -- "${0}")/../test-jac1d-100.expected"

--- a/tests/mpi/test-jac1d-100-mpi-4.sh
+++ b/tests/mpi/test-jac1d-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac1d 100 > test-jac1d-100-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac1d 100 > test-jac1d-100-mpi-4.out
 cmp test-jac1d-100-mpi-4.out "$(dirname -- "${0}")/test-jac1d-100.expected"

--- a/tests/mpi/test-jac1d-1000-repart-mpi-1.sh
+++ b/tests/mpi/test-jac1d-1000-repart-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-1.out
 cmp test-jac1d-1000-repart-mpi-1.out "$(dirname -- "${0}")/../test-jac1d-1000-repart.expected"

--- a/tests/mpi/test-jac1d-1000-repart-mpi-4.sh
+++ b/tests/mpi/test-jac1d-1000-repart-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac1d 1000 50 10 > test-jac1d-1000-repart-mpi-4.out
 cmp test-jac1d-1000-repart-mpi-4.out "$(dirname -- "${0}")/test-jac1d-1000-repart.expected"

--- a/tests/mpi/test-jac2d-1000-mpi-1.sh
+++ b/tests/mpi/test-jac2d-1000-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-1.out
 cmp test-jac2d-1000-mpi-1.out "$(dirname -- "${0}")/../test-jac2d-1000.expected"

--- a/tests/mpi/test-jac2d-1000-mpi-4.sh
+++ b/tests/mpi/test-jac2d-1000-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac2d -s 1000 > test-jac2d-1000-mpi-4.out
 cmp test-jac2d-1000-mpi-4.out "$(dirname -- "${0}")/test-jac2d-1000.expected"

--- a/tests/mpi/test-jac2dn-1000-mpi-4.sh
+++ b/tests/mpi/test-jac2dn-1000-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test with no-corners halo partitioner
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac2d -s -n 1000 > test-jac2dn-1000-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac2d -s -n 1000 > test-jac2dn-1000-mpi-4.out
 cmp test-jac2dn-1000-mpi-4.out "$(dirname -- "${0}")/test-jac2dn-1000.expected"

--- a/tests/mpi/test-jac3d-100-mpi-1.sh
+++ b/tests/mpi/test-jac3d-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-1.out
 cmp test-jac3d-100-mpi-1.out "$(dirname -- "${0}")/../test-jac3d-100.expected"

--- a/tests/mpi/test-jac3d-100-mpi-4.sh
+++ b/tests/mpi/test-jac3d-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac3d -s 100 > test-jac3d-100-mpi-4.out
 cmp test-jac3d-100-mpi-4.out "$(dirname -- "${0}")/test-jac3d-100.expected"

--- a/tests/mpi/test-jac3dn-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dn-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -s -n 100 > test-jac3dn-100-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac3d -s -n 100 > test-jac3dn-100-mpi-4.out
 cmp test-jac3dn-100-mpi-4.out "$(dirname -- "${0}")/test-jac3dn-100.expected"

--- a/tests/mpi/test-jac3dnr-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dnr-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -n -r -s 100 > test-jac3dnr-100-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac3d -n -r -s 100 > test-jac3dnr-100-mpi-4.out
 cmp test-jac3dnr-100-mpi-4.out "$(dirname -- "${0}")/test-jac3dn-100.expected"

--- a/tests/mpi/test-jac3dr-100-mpi-1.sh
+++ b/tests/mpi/test-jac3dr-100-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-1.out
 cmp test-jac3dr-100-mpi-1.out "$(dirname -- "${0}")/../test-jac3d-100.expected"

--- a/tests/mpi/test-jac3dr-100-mpi-4.sh
+++ b/tests/mpi/test-jac3dr-100-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/jac3d -r -s 100 > test-jac3dr-100-mpi-4.out
 cmp test-jac3dr-100-mpi-4.out "$(dirname -- "${0}")/test-jac3d-100.expected"

--- a/tests/mpi/test-markov-20-4-mpi-1.sh
+++ b/tests/mpi/test-markov-20-4-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/markov 20 4 > test-markov-20-4-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/markov 20 4 > test-markov-20-4-mpi-1.out
 cmp test-markov-20-4-mpi-1.out "$(dirname -- "${0}")/../test-markov-20-4.expected"

--- a/tests/mpi/test-markov-40-4-mpi-4.sh
+++ b/tests/mpi/test-markov-40-4-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/markov 40 4 > test-markov-40-4-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/markov 40 4 > test-markov-40-4-mpi-4.out
 cmp test-markov-40-4-mpi-4.out "$(dirname -- "${0}")/test-markov-40-4.expected"

--- a/tests/mpi/test-markov2-20-4-mpi-1.sh
+++ b/tests/mpi/test-markov2-20-4-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/markov2 20 4 > test-markov2-20-4-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/markov2 20 4 > test-markov2-20-4-mpi-1.out
 cmp test-markov2-20-4-mpi-1.out "$(dirname -- "${0}")/../test-markov2-20-4.expected"

--- a/tests/mpi/test-markov2-40-4-mpi-4.sh
+++ b/tests/mpi/test-markov2-40-4-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/markov2 40 4 > test-markov2-40-4-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/markov2 40 4 > test-markov2-40-4-mpi-4.out
 cmp test-markov2-40-4-mpi-4.out "$(dirname -- "${0}")/test-markov2-40-4.expected"

--- a/tests/mpi/test-propagation2d-10-mpi-1.sh
+++ b/tests/mpi/test-propagation2d-10-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-1.out
 cmp test-propagation2d-10-mpi-1.out "$(dirname -- "${0}")/../test-propagation2d-10.expected"

--- a/tests/mpi/test-propagation2d-10-mpi-4.sh
+++ b/tests/mpi/test-propagation2d-10-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/propagation2d 10 10 > test-propagation2d-10-mpi-4.out
 cmp test-propagation2d-10-mpi-4.out "$(dirname -- "${0}")/test-propagation2d-10.expected"

--- a/tests/mpi/test-spmv-mpi-1.sh
+++ b/tests/mpi/test-spmv-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv 4000 > test-spmv-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/spmv 4000 > test-spmv-mpi-1.out
 cmp test-spmv-mpi-1.out "$(dirname -- "${0}")/../test-spmv.expected"

--- a/tests/mpi/test-spmv-mpi-4.sh
+++ b/tests/mpi/test-spmv-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv 4000 | LC_ALL='C' sort > test-spmv-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/spmv 4000 | LC_ALL='C' sort > test-spmv-mpi-4.out
 cmp test-spmv-mpi-4.out "$(dirname -- "${0}")/test-spmv.expected"

--- a/tests/mpi/test-spmv2-mpi-1.sh
+++ b/tests/mpi/test-spmv2-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv2 10 3000 > test-spmv2-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/spmv2 10 3000 > test-spmv2-mpi-1.out
 cmp test-spmv2-mpi-1.out "$(dirname -- "${0}")/../test-spmv2.expected"

--- a/tests/mpi/test-spmv2-mpi-4.sh
+++ b/tests/mpi/test-spmv2-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 10 3000 | LC_ALL='C' sort > test-spmv2-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/spmv2 10 3000 | LC_ALL='C' sort > test-spmv2-mpi-4.out
 cmp test-spmv2-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2-shrink-inc-mpi-4.sh
+++ b/tests/mpi/test-spmv2-shrink-inc-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test shrinking with incremental partitioner
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -s 2 -i 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-inc-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/spmv2 -s 2 -i 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-inc-mpi-4.out
 cmp test-spmv2-shrink-inc-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2-shrink-mpi-4.sh
+++ b/tests/mpi/test-spmv2-shrink-mpi-4.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # test shrinking in spmv2
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -s 2 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/spmv2 -s 2 10 3000 | LC_ALL='C' sort > test-spmv2-shrink-mpi-4.out
 cmp test-spmv2-shrink-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-spmv2r-mpi-1.sh
+++ b/tests/mpi/test-spmv2r-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/spmv2 -r 10 3000 > test-spmv2r-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/spmv2 -r 10 3000 > test-spmv2r-mpi-1.out
 cmp test-spmv2r-mpi-1.out "$(dirname -- "${0}")/../test-spmv2.expected"

--- a/tests/mpi/test-spmv2r-mpi-4.sh
+++ b/tests/mpi/test-spmv2r-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/spmv2 -r 10 3000 | LC_ALL='C' sort > test-spmv2r-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/spmv2 -r 10 3000 | LC_ALL='C' sort > test-spmv2r-mpi-4.out
 cmp test-spmv2r-mpi-4.out "$(dirname -- "${0}")/test-spmv2.expected"

--- a/tests/mpi/test-vsum-mpi-1.sh
+++ b/tests/mpi/test-vsum-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum > test-vsum-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/vsum > test-vsum-mpi-1.out
 cmp test-vsum-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum-mpi-4.sh
+++ b/tests/mpi/test-vsum-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum | LC_ALL='C' sort > test-vsum-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/vsum | LC_ALL='C' sort > test-vsum-mpi-4.out
 cmp test-vsum-mpi-4.out "$(dirname -- "${0}")/test-vsum.expected"

--- a/tests/mpi/test-vsum2-mpi-1.sh
+++ b/tests/mpi/test-vsum2-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum2 > test-vsum2-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/vsum2 > test-vsum2-mpi-1.out
 cmp test-vsum2-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum2-mpi-4.sh
+++ b/tests/mpi/test-vsum2-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum2 | LC_ALL='C' sort > test-vsum2-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/vsum2 | LC_ALL='C' sort > test-vsum2-mpi-4.out
 cmp test-vsum2-mpi-4.out "$(dirname -- "${0}")/test-vsum2.expected"

--- a/tests/mpi/test-vsum3-mpi-1.sh
+++ b/tests/mpi/test-vsum3-mpi-1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 1 ../../examples/vsum3 > test-vsum3-mpi-1.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 1 ../../examples/vsum3 > test-vsum3-mpi-1.out
 cmp test-vsum3-mpi-1.out "$(dirname -- "${0}")/../test-vsum.expected"

--- a/tests/mpi/test-vsum3-mpi-4.sh
+++ b/tests/mpi/test-vsum3-mpi-4.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-LAIK_BACKEND=mpi mpirun -np 4 ../../examples/vsum3 | LC_ALL='C' sort > test-vsum3-mpi-4.out
+LAIK_BACKEND=mpi ${MPIEXEC-mpiexec} -n 4 ../../examples/vsum3 | LC_ALL='C' sort > test-vsum3-mpi-4.out
 cmp test-vsum3-mpi-4.out "$(dirname -- "${0}")/test-vsum.expected"


### PR DESCRIPTION
This PR makes the following possible:

# Building with OpenMPI

```
$ cd build-ompi/
$ cmake -D mpi-implementation=ompi ..
[...]
$ make
[...]
$ ctest
[...]
$ ldd examples/vsum | grep libmpi
	libmpi.so.40 => /usr/lib/x86_64-linux-gnu/libmpi.so.40 (0x00007f8ea9367000)
$ 
```

# Building with MPICH

```
$ cd build-mpich/
$ cmake -D mpi-implementation=mpich ..
[...]
$ make
[...]
$ ctest
[...]
$ ldd examples/vsum | grep libmpi
	libmpich.so.0 => /usr/lib/x86_64-linux-gnu/libmpich.so.0 (0x00007fd8c485d000)
$ 
```

Furthermore, this PR also addresses #155 by passing the ```--oversubscribe``` option when OpenMPI is requested explicitly.