### PR TITLE
tests/tcp/common.sh: Use TCP sockets in the tests.

### DIFF
--- a/tests/tcp/common.sh
+++ b/tests/tcp/common.sh
@@ -1,22 +1,30 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 
 run()(
     IFS='_'
-    idx="0"
 
-    while [ "${idx}" -lt "${OMPI_COMM_WORLD_SIZE}" ]; do
+    export LAIK_BACKEND='tcp'
+    export LAIK_TCP_CONFIG="`mktemp`"
+
+    printf '%s\n' \
+        '[addresses]' \
+        "rank0 = localhost $((10000 + ($$ % 5000) * 4 + 0))" \
+        "rank1 = localhost $((10000 + ($$ % 5000) * 4 + 1))" \
+        "rank2 = localhost $((10000 + ($$ % 5000) * 4 + 2))" \
+        "rank3 = localhost $((10000 + ($$ % 5000) * 4 + 3))" \
+        > "${LAIK_TCP_CONFIG}"
+
+    for i in 1 2 3 4; do
         ../../examples/${1} &
-        idx="$((idx + 1))"
     done
 
     wait
+
+    rm -- "${LAIK_TCP_CONFIG}"
 )
 
 dir="`dirname -- "${0}"`"
 name="`basename -- "${0%.sh}"`"
-
-export LAIK_BACKEND='tcp'
-export OMPI_COMM_WORLD_SIZE='4'
 
 if [ -f "${dir}/${name}.unsorted" ]; then
     run "${name}" | diff --unified -- "${dir}/${name}.unsorted" -


### PR DESCRIPTION
This makes the tests work on MacOS which doesn't have abstract UNIX sockets.
Unfortunately, this also means that we have to occupy part of the globally
shared TCP port namespace (using a separate networking namespace would require
root priviledges and probably also be Linux-only). This means that the tests
might very well fail because something else has already bound the required
port or because another test is run in parallel.

This commit tries to the reduce the risk of these two things happening by
using the following formula to dynamically allocate ports for the tests:

    port = 10000 + (PID % 5000) * 4 + i       (where i ∈ {0,1,2,3})

This means that the tests will only use ports between 10000 and 30000 which
should hopefully not be used by other services or outgoing TCP connections.
Furthermore, collisions between two tests are only possible if the test
scripts' PIDs are equal (mod 5000). In my tests, this approach has proven to
be very reliable, but it is of course still entirely possible that the tests now
fail because of unrelated network activity or port collisions.

Closes #157.